### PR TITLE
fix(graph): reopen node detail modal on repeated node click

### DIFF
--- a/ui/src/components/GraphCanvas.tsx
+++ b/ui/src/components/GraphCanvas.tsx
@@ -423,6 +423,7 @@ export function GraphCanvas({
         onNodeDragStart={handleNodeDragStart}
         onPaneClick={handlePaneClick}
         onPaneContextMenu={(e) => handleContextMenu(e)}
+        onNodeClick={(_, rfNode) => { if (rfNode.type === "workflow") onSelectNode(rfNode.id); }}
         onNodeContextMenu={(e, rfNode) => handleContextMenu(e, rfNode)}
         deleteKeyCode={["Backspace", "Delete"]}
         selectionOnDrag

--- a/ui/src/hooks/useNodeSync.ts
+++ b/ui/src/hooks/useNodeSync.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
   type Node as RFNode,
   type OnNodesChange,
@@ -720,7 +720,9 @@ export function useNodeSync({
   ]);
 
   // Sync external selectedNode changes into RF selection state
-  useEffect(() => {
+  // useLayoutEffect ensures deselection runs before paint, preventing a frame where
+  // rfNodes still shows the node as selected after the modal closes.
+  useLayoutEffect(() => {
     if (selectionFromCanvasRef.current) {
       selectionFromCanvasRef.current = false;
       return;


### PR DESCRIPTION
After closing the NodeDetailModal, clicking the same node again failed to reopen it because ReactFlow's internal selection state lagged behind the programmatic deselection, causing it to suppress the select: true change event.

Two fixes:

 - Add onNodeClick to ReactFlow that calls onSelectNode directly for workflow nodes, bypassing RF's internal selection state entirely

 - Switch the selection sync from useEffect to useLayoutEffect so deselection runs before paint, closing the race window where a fast click could land while RF still considered the node selected