### PR TITLE
feat: per-node Chrome profile selection

### DIFF
--- a/crates/clickweave-core/src/chrome_profiles.rs
+++ b/crates/clickweave-core/src/chrome_profiles.rs
@@ -108,6 +108,18 @@ impl ChromeProfileStore {
             .map(String::from)
     }
 
+    /// Resolve a profile display name to its filesystem path (case-insensitive).
+    /// Strips trailing " (email)" suffixes so the LLM can include the email without breaking resolution.
+    /// Returns `None` if no profile matches.
+    pub fn resolve_profile_path_by_name(&self, name: &str) -> Option<PathBuf> {
+        let stripped = name.find(" (").map(|i| &name[..i]).unwrap_or(name);
+        let lower = stripped.to_lowercase();
+        self.load_profiles()
+            .into_iter()
+            .find(|p| p.name.to_lowercase() == lower)
+            .map(|p| self.profile_path(&p.id))
+    }
+
     /// Ensure at least one profile exists. Returns all profiles.
     pub fn ensure_profiles(&self) -> std::io::Result<Vec<ChromeProfile>> {
         if self.load_entries().is_empty() {
@@ -214,6 +226,38 @@ mod tests {
         let base = TempDir::new().unwrap();
         let store = ChromeProfileStore::new(base.path().to_path_buf());
         assert_eq!(store.read_google_email("nonexistent"), None);
+    }
+
+    #[test]
+    fn resolve_profile_path_by_name_case_insensitive() {
+        let base = TempDir::new().unwrap();
+        let store = ChromeProfileStore::new(base.path().to_path_buf());
+        store.create_profile("Work Account").unwrap();
+
+        // Exact match
+        let result = store.resolve_profile_path_by_name("Work Account");
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), store.profile_path("work-account"));
+
+        // Case-insensitive
+        let result = store.resolve_profile_path_by_name("work account");
+        assert!(result.is_some());
+
+        // No match
+        let result = store.resolve_profile_path_by_name("Personal");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn resolve_profile_path_by_name_strips_email_suffix() {
+        let base = TempDir::new().unwrap();
+        let store = ChromeProfileStore::new(base.path().to_path_buf());
+        store.create_profile("Your Chrome").unwrap();
+
+        // LLM may include email suffix copied from the prompt display
+        let result = store.resolve_profile_path_by_name("Your Chrome (ves.lisica@gmail.com)");
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), store.profile_path("your-chrome"));
     }
 
     #[test]

--- a/crates/clickweave-core/src/node_params.rs
+++ b/crates/clickweave-core/src/node_params.rs
@@ -262,6 +262,8 @@ pub struct FocusWindowParams {
     pub bring_to_front: bool,
     #[serde(default)]
     pub app_kind: AppKind,
+    #[serde(default)]
+    pub chrome_profile_id: Option<String>,
 }
 
 impl Default for FocusWindowParams {
@@ -271,6 +273,7 @@ impl Default for FocusWindowParams {
             value: None,
             bring_to_front: true,
             app_kind: AppKind::Native,
+            chrome_profile_id: None,
         }
     }
 }

--- a/crates/clickweave-core/src/tool_mapping.rs
+++ b/crates/clickweave-core/src/tool_mapping.rs
@@ -330,6 +330,7 @@ pub fn tool_invocation_to_node_type(
                 value,
                 bring_to_front: true,
                 app_kind,
+                chrome_profile_id: None,
             }))
         }
         _ if known_tools
@@ -524,6 +525,7 @@ mod tests {
             value: Some("Safari".into()),
             bring_to_front: true,
             app_kind: AppKind::Native,
+            chrome_profile_id: None,
         });
         let inv = node_type_to_tool_invocation(&nt).unwrap();
         assert_eq!(inv.name, "focus_window");
@@ -540,6 +542,7 @@ mod tests {
             value: Some("42".into()),
             bring_to_front: true,
             app_kind: AppKind::Native,
+            chrome_profile_id: None,
         });
         let inv = node_type_to_tool_invocation(&nt).unwrap();
         let back = tool_invocation_to_node_type(&inv.name, &inv.arguments, &[]).unwrap();
@@ -555,6 +558,7 @@ mod tests {
             value: Some("1234".into()),
             bring_to_front: true,
             app_kind: AppKind::Native,
+            chrome_profile_id: None,
         });
         let inv = node_type_to_tool_invocation(&nt).unwrap();
         let back = tool_invocation_to_node_type(&inv.name, &inv.arguments, &[]).unwrap();
@@ -647,6 +651,7 @@ mod tests {
             value: Some("Chrome".into()),
             bring_to_front: true,
             app_kind: AppKind::ChromeBrowser,
+            chrome_profile_id: None,
         });
         let inv = node_type_to_tool_invocation(&nt).unwrap();
         assert_eq!(inv.arguments["app_kind"], "ChromeBrowser");
@@ -664,6 +669,7 @@ mod tests {
             value: Some("Calculator".into()),
             bring_to_front: true,
             app_kind: AppKind::Native,
+            chrome_profile_id: None,
         });
         let inv = node_type_to_tool_invocation(&nt).unwrap();
         assert!(inv.arguments.get("app_kind").is_none());

--- a/crates/clickweave-core/src/walkthrough/synthesis.rs
+++ b/crates/clickweave-core/src/walkthrough/synthesis.rs
@@ -413,6 +413,7 @@ pub fn synthesize_draft(
                     value: Some(app_name.clone()),
                     bring_to_front: true,
                     app_kind: *app_kind,
+                    chrome_profile_id: None,
                 }),
                 format!("Launch {app_name}"),
             ),
@@ -427,6 +428,7 @@ pub fn synthesize_draft(
                     value: Some(app_name.clone()),
                     bring_to_front: true,
                     app_kind: *app_kind,
+                    chrome_profile_id: None,
                 }),
                 match window_title {
                     Some(t) => format!("Focus '{t}'"),

--- a/crates/clickweave-engine/src/executor/deterministic/cdp.rs
+++ b/crates/clickweave-engine/src/executor/deterministic/cdp.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use super::super::{ExecutorError, ExecutorResult, Mcp, WorkflowExecutor};
 use clickweave_core::ClickTarget;
 use clickweave_core::NodeRun;
@@ -270,6 +272,7 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
         app_name: &str,
         mcp: &(impl Mcp + ?Sized),
         node_run: Option<&NodeRun>,
+        chrome_profile_path: Option<&Path>,
     ) -> ExecutorResult<()> {
         use clickweave_core::ExecutionMode;
         use clickweave_core::decision_cache::CdpPort;
@@ -287,24 +290,31 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
 
         let port = if self.execution_mode == ExecutionMode::Test {
             // Try reusing an existing debug port before doing a full relaunch.
-            let reused = if let Some(existing_port) = existing_debug_port(app_name).await {
-                self.log(format!(
-                    "'{}' already running with --remote-debugging-port={}, reusing",
-                    app_name, existing_port
-                ));
-                if self.try_cdp_connect(app_name, existing_port, mcp).await {
-                    self.write_decision_cache().cdp_port.insert(
-                        app_name.to_string(),
-                        CdpPort {
-                            port: existing_port,
-                        },
-                    );
-                    Some(existing_port)
-                } else {
+            // Skip reuse when an explicit Chrome profile is provided — we need
+            // a fresh instance with that profile's --user-data-dir, not whatever
+            // Chrome is currently running.
+            let reused = if chrome_profile_path.is_none() {
+                if let Some(existing_port) = existing_debug_port(app_name).await {
                     self.log(format!(
-                        "Existing debug port {} for '{}' was unreachable, relaunching",
-                        existing_port, app_name
+                        "'{}' already running with --remote-debugging-port={}, reusing",
+                        app_name, existing_port
                     ));
+                    if self.try_cdp_connect(app_name, existing_port, mcp).await {
+                        self.write_decision_cache().cdp_port.insert(
+                            app_name.to_string(),
+                            CdpPort {
+                                port: existing_port,
+                            },
+                        );
+                        Some(existing_port)
+                    } else {
+                        self.log(format!(
+                            "Existing debug port {} for '{}' was unreachable, relaunching",
+                            existing_port, app_name
+                        ));
+                        None
+                    }
+                } else {
                     None
                 }
             } else {
@@ -319,7 +329,8 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
                     "Restarting '{}' with DevTools enabled (port {})...",
                     app_name, port
                 ));
-                self.relaunch_with_debug_port(app_name, port, mcp).await?;
+                self.relaunch_with_debug_port(app_name, port, mcp, chrome_profile_path)
+                    .await?;
                 self.evict_app_cache(app_name);
                 self.write_decision_cache()
                     .cdp_port
@@ -346,7 +357,8 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
                     "CDP connection failed for '{}', relaunching with port {}...",
                     app_name, port
                 ));
-                self.relaunch_with_debug_port(app_name, port, mcp).await?;
+                self.relaunch_with_debug_port(app_name, port, mcp, chrome_profile_path)
+                    .await?;
                 self.evict_app_cache(app_name);
                 self.cdp_connect_and_poll(app_name, port, mcp).await?;
             }
@@ -445,13 +457,14 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
         app_name: &str,
         port: u16,
         mcp: &(impl Mcp + ?Sized),
+        chrome_profile_path: Option<&Path>,
     ) -> ExecutorResult<()> {
         let is_chrome = {
             let lower = app_name.to_lowercase();
             lower.contains("chrome") || lower.contains("chromium")
         };
 
-        if let (true, Some(profile_path)) = (is_chrome, self.chrome_profile_path.as_ref()) {
+        if let (true, Some(profile_path)) = (is_chrome, chrome_profile_path) {
             // Chrome with a configured profile: kill only the profile-specific
             // instance, then launch directly (bypasses MCP launch_app which
             // refuses when any Chrome is already running).

--- a/crates/clickweave-engine/src/executor/deterministic/mod.rs
+++ b/crates/clickweave-engine/src/executor/deterministic/mod.rs
@@ -555,8 +555,16 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
 
             // Lazy CDP connection for Electron/Chrome apps.
             if app_kind.uses_cdp() && mcp.has_tool("cdp_connect") {
-                self.ensure_cdp_connected(node_id, &app.name, mcp, node_run.as_deref())
-                    .await?;
+                let profile_path =
+                    self.resolve_chrome_profile_path(p.chrome_profile_id.as_deref())?;
+                self.ensure_cdp_connected(
+                    node_id,
+                    &app.name,
+                    mcp,
+                    node_run.as_deref(),
+                    profile_path.as_deref(),
+                )
+                .await?;
                 // Re-resolve PID -- it may have changed if the app was relaunched.
                 app = self
                     .resolve_app_name(node_id, user_input, mcp, node_run.as_deref())
@@ -570,6 +578,7 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
                 value: Some(app.pid.to_string()),
                 bring_to_front: p.bring_to_front,
                 app_kind,
+                chrome_profile_id: p.chrome_profile_id.clone(),
             });
             &resolved_fw
         } else {
@@ -638,25 +647,41 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
             AppKind::Native
         };
 
+        let launch_chrome_profile = if tool_name == "launch_app" {
+            args.as_ref()
+                .and_then(|a| a.get("chrome_profile"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        } else {
+            None
+        };
+
         // For Chrome-family launch_app with a configured profile: kill only the
         // Chrome instance running this profile (leave the user's default Chrome
         // alone), then launch Chrome directly with --user-data-dir. We bypass the
         // MCP launch_app tool which refuses when any Chrome is already running.
         if tool_name == "launch_app"
             && launch_app_kind == AppKind::ChromeBrowser
-            && let Some(ref profile_path) = self.chrome_profile_path
+            && let Some(profile_path) =
+                self.resolve_chrome_profile_path(launch_chrome_profile.as_deref())?
         {
             let dir = profile_path.to_string_lossy().to_string();
             self.log(format!("Launching Chrome with profile: {}", dir));
 
-            kill_chrome_profile_instance(&dir).await;
+            let use_cdp = launch_app_kind.uses_cdp() && mcp.has_tool("cdp_connect");
 
-            launch_chrome_with_profile(&dir)
-                .await
-                .map_err(|e| ExecutorError::ToolCall {
-                    tool: "launch_app".to_string(),
-                    message: format!("Failed to launch Chrome with profile: {e}"),
-                })?;
+            if !use_cdp {
+                // No CDP available: launch now without debug port.
+                kill_chrome_profile_instance(&dir).await;
+                launch_chrome_with_profile(&dir)
+                    .await
+                    .map_err(|e| ExecutorError::ToolCall {
+                        tool: "launch_app".to_string(),
+                        message: format!("Failed to launch Chrome with profile: {e}"),
+                    })?;
+                // Wait for Chrome to start up before continuing.
+                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            }
 
             self.record_event(
                 node_run.as_deref(),
@@ -667,14 +692,26 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
                 }),
             );
 
-            // Wait for Chrome to start up before continuing.
-            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-
             if let Some(name) = &launch_app_name {
                 *self.write_focused_app() = Some((name.clone(), launch_app_kind));
-                if launch_app_kind.uses_cdp() && mcp.has_tool("cdp_connect") {
-                    self.ensure_cdp_connected(node_id, name, mcp, node_run.as_deref())
-                        .await?;
+                if use_cdp {
+                    // Force-disconnect any existing CDP session: a new profile
+                    // launch kills the previous Chrome instance, so any old CDP
+                    // connection is stale. Without this, ensure_cdp_connected
+                    // short-circuits on the app name match and never connects
+                    // to the new profile's Chrome instance.
+                    if self.cdp_connected_app.is_some() {
+                        let _ = mcp.call_tool("cdp_disconnect", None).await;
+                        self.cdp_connected_app = None;
+                    }
+                    self.ensure_cdp_connected(
+                        node_id,
+                        name,
+                        mcp,
+                        node_run.as_deref(),
+                        Some(profile_path.as_path()),
+                    )
+                    .await?;
                 }
             }
 
@@ -715,8 +752,15 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
 
             // Lazy CDP connection for Electron/Chrome apps (same as FocusWindow path).
             if launch_app_kind.uses_cdp() && mcp.has_tool("cdp_connect") {
-                self.ensure_cdp_connected(node_id, name, mcp, node_run.as_deref())
-                    .await?;
+                let profile_path = self.resolve_chrome_profile_path(None)?;
+                self.ensure_cdp_connected(
+                    node_id,
+                    name,
+                    mcp,
+                    node_run.as_deref(),
+                    profile_path.as_deref(),
+                )
+                .await?;
             }
         }
 

--- a/crates/clickweave-engine/src/executor/mod.rs
+++ b/crates/clickweave-engine/src/executor/mod.rs
@@ -17,6 +17,7 @@ pub use error::*;
 mod tests;
 
 use clickweave_core::AppKind;
+use clickweave_core::chrome_profiles::{ChromeProfile, ChromeProfileStore};
 use clickweave_core::decision_cache::DecisionCache;
 use clickweave_core::runtime::RuntimeContext;
 use clickweave_core::storage::RunStorage;
@@ -146,9 +147,10 @@ pub struct WorkflowExecutor<C: ChatBackend = LlmClient> {
     /// `cdp_list_pages` until the URL moves away from NTP/blank so that
     /// supervision fires when Chrome is already loading the destination page.
     last_typed_url: Option<String>,
-    /// Persistent Chrome user-data-dir path for `--remote-debugging-port` sessions.
-    /// When set, used as `--user-data-dir` instead of a hardcoded path.
-    chrome_profile_path: Option<PathBuf>,
+    /// Store for Chrome user-data-dir profiles (resolves profile names to paths).
+    chrome_profile_store: ChromeProfileStore,
+    /// Cached profile list, loaded once at construction.
+    chrome_profiles: Vec<ChromeProfile>,
 }
 
 pub(crate) struct PendingLoopExit {
@@ -186,8 +188,13 @@ impl WorkflowExecutor {
         event_tx: Sender<ExecutorEvent>,
         storage: RunStorage,
         cancel_token: CancellationToken,
-        chrome_profile_path: Option<PathBuf>,
+        chrome_profiles_dir: PathBuf,
     ) -> Self {
+        let chrome_profile_store = ChromeProfileStore::new(chrome_profiles_dir);
+        let chrome_profiles = chrome_profile_store.ensure_profiles().unwrap_or_else(|e| {
+            tracing::warn!("Chrome profile setup failed (non-fatal): {e}");
+            chrome_profile_store.load_profiles()
+        });
         let decision_cache = DecisionCache::load(&storage.cache_path())
             .unwrap_or_else(|| DecisionCache::new(workflow.id));
         let verdict_vlm = vlm_config
@@ -221,7 +228,8 @@ impl WorkflowExecutor {
             last_click_was_cdp: false,
             last_url_navigation_was_cdp: false,
             last_typed_url: None,
-            chrome_profile_path,
+            chrome_profile_store,
+            chrome_profiles,
         }
     }
 }
@@ -318,6 +326,42 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
         self.tried_cdp_uids
             .write()
             .unwrap_or_else(|e| e.into_inner())
+    }
+
+    // ── Chrome profile resolution ────────────────────────────────────────
+
+    /// Resolve a chrome_profile name from launch_app arguments to a filesystem path.
+    /// Falls back to the first available profile if no name is provided.
+    /// Returns an error if a name is provided but doesn't match any profile.
+    pub(crate) fn resolve_chrome_profile_path(
+        &self,
+        chrome_profile_name: Option<&str>,
+    ) -> ExecutorResult<Option<PathBuf>> {
+        match chrome_profile_name {
+            Some(name) => self
+                .chrome_profile_store
+                .resolve_profile_path_by_name(name)
+                .map(Some)
+                .ok_or_else(|| {
+                    let available: Vec<&str> = self
+                        .chrome_profiles
+                        .iter()
+                        .map(|p| p.name.as_str())
+                        .collect();
+                    ExecutorError::ToolCall {
+                        tool: "launch_app".to_string(),
+                        message: format!(
+                            "Unknown Chrome profile '{}'. Available profiles: {}",
+                            name,
+                            available.join(", ")
+                        ),
+                    }
+                }),
+            None => Ok(self
+                .chrome_profiles
+                .first()
+                .map(|p| self.chrome_profile_store.profile_path(&p.id))),
+        }
     }
 
     // ── Convenience accessors ────────────────────────────────────────────

--- a/crates/clickweave-engine/src/executor/tests/cache.rs
+++ b/crates/clickweave-engine/src/executor/tests/cache.rs
@@ -89,6 +89,7 @@ fn evict_app_cache_for_focus_window_node() {
         value: Some("chrome".to_string()),
         bring_to_front: true,
         app_kind: clickweave_core::AppKind::Native,
+        chrome_profile_id: None,
     });
     exec.evict_caches_for_node(&node);
     assert!(!exec.app_cache.read().unwrap().contains_key("chrome"));

--- a/crates/clickweave-engine/src/executor/tests/helpers.rs
+++ b/crates/clickweave-engine/src/executor/tests/helpers.rs
@@ -232,7 +232,10 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
             last_click_was_cdp: false,
             last_url_navigation_was_cdp: false,
             last_typed_url: None,
-            chrome_profile_path: None,
+            chrome_profile_store: clickweave_core::chrome_profiles::ChromeProfileStore::new(
+                std::env::temp_dir().join("clickweave_test_profiles"),
+            ),
+            chrome_profiles: Vec::new(),
         }
     }
 }

--- a/crates/clickweave-llm/prompts/planner.md
+++ b/crates/clickweave-llm/prompts/planner.md
@@ -49,6 +49,7 @@ Before outputting, verify: count nodes with zero incoming edges. If more than 1,
 - Output ONLY valid JSON. No explanation, no markdown fences.
 - For Chrome-family browsers (Chrome, Brave, Edge, Arc, Chromium), add `"app_kind": "ChromeBrowser"` to launch_app/focus_window arguments. For all other apps, omit app_kind (defaults to Native). Do NOT guess Electron apps — the executor detects those automatically.
 - For Chrome navigation: after launch_app, type the URL directly with type_text, then press return. Do NOT use press_key shortcuts (e.g. Cmd+N, Cmd+T) to open new windows or tabs — the launch_app node already provides a usable window.
+{{chrome_profiles}}
 
 ## Conditional example
 

--- a/crates/clickweave-llm/src/bin/planner_eval.rs
+++ b/crates/clickweave-llm/src/bin/planner_eval.rs
@@ -590,6 +590,7 @@ async fn main() -> Result<()> {
                                 false,
                                 false,
                                 Some(&template),
+                                None,
                             )
                             .await
                             {

--- a/crates/clickweave-llm/src/planner/assistant.rs
+++ b/crates/clickweave-llm/src/planner/assistant.rs
@@ -6,7 +6,7 @@ use super::summarize::summarize_overflow;
 use super::{PatchResult, PatcherOutput, PlannerGraphOutput, PlannerOutput};
 use crate::{ChatBackend, LlmClient, LlmConfig, Message};
 use anyhow::Result;
-use clickweave_core::{Edge, Node, Workflow, validate_workflow};
+use clickweave_core::{Edge, Node, Workflow, chrome_profiles::ChromeProfile, validate_workflow};
 use serde_json::Value;
 use std::collections::HashSet;
 use tracing::{info, warn};
@@ -36,6 +36,7 @@ pub async fn assistant_chat(
     allow_agent_steps: bool,
     max_repair_attempts: usize,
     on_repair_attempt: Option<&(dyn Fn(usize, usize) + Send + Sync)>,
+    chrome_profiles: Option<&[ChromeProfile]>,
 ) -> Result<AssistantResult> {
     let client = LlmClient::new(config);
     assistant_chat_with_backend(
@@ -49,6 +50,7 @@ pub async fn assistant_chat(
         allow_agent_steps,
         max_repair_attempts,
         on_repair_attempt,
+        chrome_profiles,
     )
     .await
 }
@@ -66,6 +68,7 @@ pub async fn assistant_chat_with_backend(
     allow_agent_steps: bool,
     max_repair_attempts: usize,
     on_repair_attempt: Option<&(dyn Fn(usize, usize) + Send + Sync)>,
+    chrome_profiles: Option<&[ChromeProfile]>,
 ) -> Result<AssistantResult> {
     // 1. Optionally summarize overflow (non-fatal on error)
     let new_summary = if session.needs_summarization(None) {
@@ -91,6 +94,7 @@ pub async fn assistant_chat_with_backend(
         allow_ai_transforms,
         allow_agent_steps,
         run_context_text,
+        chrome_profiles,
     );
 
     // 3. Assemble messages: system + optional summary context + recent window + new user message

--- a/crates/clickweave-llm/src/planner/plan.rs
+++ b/crates/clickweave-llm/src/planner/plan.rs
@@ -5,7 +5,9 @@ use super::repair::chat_with_repair;
 use super::{PlanResult, PlanStep, PlannerOutput};
 use crate::{ChatBackend, LlmClient, LlmConfig, Message};
 use anyhow::{Context, Result, anyhow};
-use clickweave_core::{Edge, Node, NodeRole, Workflow, validate_workflow};
+use clickweave_core::{
+    Edge, Node, NodeRole, Workflow, chrome_profiles::ChromeProfile, validate_workflow,
+};
 use serde::Deserialize;
 use serde_json::Value;
 use tracing::{debug, info};
@@ -30,6 +32,7 @@ pub async fn plan_workflow(
     mcp_tools_openai: &[Value],
     allow_ai_transforms: bool,
     allow_agent_steps: bool,
+    chrome_profiles: Option<&[ChromeProfile]>,
 ) -> Result<PlanResult> {
     let planner = LlmClient::new(planner_config);
     plan_workflow_with_backend(
@@ -39,6 +42,7 @@ pub async fn plan_workflow(
         allow_ai_transforms,
         allow_agent_steps,
         None,
+        chrome_profiles,
     )
     .await
 }
@@ -55,12 +59,14 @@ pub async fn plan_workflow_with_backend(
     allow_ai_transforms: bool,
     allow_agent_steps: bool,
     prompt_template: Option<&str>,
+    chrome_profiles: Option<&[ChromeProfile]>,
 ) -> Result<PlanResult> {
     let system = planner_system_prompt(
         mcp_tools_openai,
         allow_ai_transforms,
         allow_agent_steps,
         prompt_template,
+        chrome_profiles,
     );
     let user_msg = format!("Plan a workflow for: {}", intent);
 

--- a/crates/clickweave-llm/src/planner/prompt.rs
+++ b/crates/clickweave-llm/src/planner/prompt.rs
@@ -1,4 +1,4 @@
-use clickweave_core::{NodeType, Workflow, tool_mapping};
+use clickweave_core::{NodeType, Workflow, chrome_profiles::ChromeProfile, tool_mapping};
 use serde_json::Value;
 
 /// Build the planner system prompt.
@@ -10,6 +10,7 @@ pub(crate) fn planner_system_prompt(
     allow_ai_transforms: bool,
     allow_agent_steps: bool,
     template_override: Option<&str>,
+    chrome_profiles: Option<&[ChromeProfile]>,
 ) -> String {
     let tool_list = serde_json::to_string_pretty(tools_json).unwrap_or_default();
 
@@ -92,11 +93,33 @@ Verification failures stop the workflow immediately (fail-fast).
 
 Use `"role": "Verification"` when the user asks to **verify**, **check**, **confirm**, or **assert** a result. Do NOT use it for navigation lookups (e.g., finding a button to click)."#);
 
+    let chrome_profiles_section = match chrome_profiles {
+        Some(profiles) if profiles.len() > 1 => {
+            let mut lines = String::from(
+                "\n## Chrome profiles\n\nAvailable Chrome profiles for browser sessions:\n",
+            );
+            for p in profiles {
+                match &p.google_email {
+                    Some(email) => {
+                        lines.push_str(&format!("- \"{}\" (signed in as {})\n", p.name, email))
+                    }
+                    None => lines.push_str(&format!("- \"{}\"\n", p.name)),
+                }
+            }
+            lines.push_str(
+                "\nWhen the user specifies which Chrome profile to use, add `\"chrome_profile\": \"<name>\"` to the launch_app arguments alongside `\"app_kind\": \"ChromeBrowser\"`. Use the exact profile name shown in quotes above (do NOT include the email). Only include this when explicitly requested.",
+            );
+            lines
+        }
+        _ => String::new(),
+    };
+
     let template = template_override.unwrap_or(include_str!("../../prompts/planner.md"));
 
     template
         .replace("{{tool_list}}", &tool_list)
         .replace("{{step_types}}", &step_types)
+        .replace("{{chrome_profiles}}", &chrome_profiles_section)
 }
 
 /// Build the patcher system prompt.
@@ -227,9 +250,16 @@ pub(crate) fn assistant_system_prompt(
     allow_ai_transforms: bool,
     allow_agent_steps: bool,
     run_context: Option<&str>,
+    chrome_profiles: Option<&[ChromeProfile]>,
 ) -> String {
     if workflow.nodes.is_empty() {
-        let base = planner_system_prompt(tools_json, allow_ai_transforms, allow_agent_steps, None);
+        let base = planner_system_prompt(
+            tools_json,
+            allow_ai_transforms,
+            allow_agent_steps,
+            None,
+            chrome_profiles,
+        );
         let mut prompt = format!(
             "You are a conversational workflow assistant for UI automation. \
              You help users create and modify workflows through natural dialogue.\n\n\

--- a/crates/clickweave-llm/src/planner/tests/assistant.rs
+++ b/crates/clickweave-llm/src/planner/tests/assistant.rs
@@ -94,6 +94,7 @@ async fn test_assistant_chat_plans_empty_workflow() {
         false,
         0,
         None,
+        None,
     )
     .await
     .unwrap();
@@ -130,6 +131,7 @@ async fn test_assistant_chat_patches_existing_workflow() {
         false,
         0,
         None,
+        None,
     )
     .await
     .unwrap();
@@ -164,6 +166,7 @@ async fn test_assistant_chat_conversational_response() {
         false,
         0,
         None,
+        None,
     )
     .await
     .unwrap();
@@ -177,7 +180,7 @@ async fn test_assistant_chat_conversational_response() {
 #[test]
 fn test_assistant_prompt_empty_workflow_includes_control_flow() {
     let wf = Workflow::new("Test");
-    let prompt = assistant_system_prompt(&wf, &[], false, false, None);
+    let prompt = assistant_system_prompt(&wf, &[], false, false, None, None);
     assert!(
         prompt.contains("Loop"),
         "Assistant prompt should mention Loop"
@@ -191,7 +194,7 @@ fn test_assistant_prompt_empty_workflow_includes_control_flow() {
 #[test]
 fn test_assistant_prompt_existing_workflow_includes_control_flow() {
     let (_, workflow) = single_node_workflow(NodeType::Click(ClickParams::default()), "Click");
-    let prompt = assistant_system_prompt(&workflow, &[], false, false, None);
+    let prompt = assistant_system_prompt(&workflow, &[], false, false, None, None);
     assert!(
         prompt.contains("add_nodes"),
         "Patcher assistant prompt should mention add_nodes for control flow"
@@ -208,6 +211,7 @@ async fn test_assistant_patches_with_add_nodes_and_add_edges() {
             value: Some("Calculator".to_string()),
             bring_to_front: true,
             app_kind: clickweave_core::AppKind::Native,
+            chrome_profile_id: None,
         }),
         "Focus Calculator",
     );
@@ -240,6 +244,7 @@ async fn test_assistant_patches_with_add_nodes_and_add_edges() {
         false,
         false,
         0,
+        None,
         None,
     )
     .await
@@ -293,6 +298,7 @@ async fn test_assistant_plans_graph_format_for_empty_workflow() {
         false,
         false,
         0,
+        None,
         None,
     )
     .await
@@ -349,6 +355,7 @@ async fn test_assistant_retry_succeeds_on_second_attempt() {
         false,
         3,
         None,
+        None,
     )
     .await
     .unwrap();
@@ -400,6 +407,7 @@ async fn test_assistant_repair_callback_is_invoked() {
         false,
         3,
         Some(&on_repair),
+        None,
     )
     .await
     .unwrap();
@@ -439,6 +447,7 @@ async fn test_assistant_retry_exhausted_returns_last_patch() {
         false,
         false,
         3, // value 3 → validate + 2 retries = 3 LLM calls max
+        None,
         None,
     )
     .await
@@ -480,6 +489,7 @@ async fn test_assistant_no_validation_when_max_is_zero() {
         false,
         0, // 0 = skip validation entirely
         None,
+        None,
     )
     .await
     .unwrap();
@@ -519,6 +529,7 @@ async fn test_assistant_validate_only_no_retry_when_max_is_one() {
         false,
         1, // 1 = validate only, no retry
         None,
+        None,
     )
     .await
     .unwrap();
@@ -548,6 +559,7 @@ async fn test_assistant_valid_patch_no_retry_needed() {
         false,
         false,
         3, // retries enabled, but not needed
+        None,
         None,
     )
     .await

--- a/crates/clickweave-llm/src/planner/tests/control_flow.rs
+++ b/crates/clickweave-llm/src/planner/tests/control_flow.rs
@@ -243,10 +243,17 @@ async fn test_infer_loop_edges_from_unlabeled() {
     ]}"#;
 
     let mock = MockBackend::single(response);
-    let result =
-        plan_workflow_with_backend(&mock, "Loop test", &sample_tools(), false, false, None)
-            .await
-            .unwrap();
+    let result = plan_workflow_with_backend(
+        &mock,
+        "Loop test",
+        &sample_tools(),
+        false,
+        false,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
 
     let wf = &result.workflow;
     let loop_node = wf
@@ -303,6 +310,7 @@ async fn test_infer_loop_reroutes_back_edge_through_endloop() {
         &sample_tools(),
         false,
         false,
+        None,
         None,
     )
     .await
@@ -402,6 +410,7 @@ async fn test_infer_loop_clears_stale_output_on_rerouted_back_edge() {
         false,
         false,
         None,
+        None,
     )
     .await
     .unwrap();
@@ -448,9 +457,10 @@ async fn test_infer_if_edges_from_unlabeled() {
     ]}"#;
 
     let mock = MockBackend::single(response);
-    let result = plan_workflow_with_backend(&mock, "If check", &sample_tools(), false, false, None)
-        .await
-        .unwrap();
+    let result =
+        plan_workflow_with_backend(&mock, "If check", &sample_tools(), false, false, None, None)
+            .await
+            .unwrap();
 
     let wf = &result.workflow;
     let if_node = wf
@@ -566,6 +576,7 @@ async fn test_infer_loop_reroutes_body_back_edge_when_endloop_edge_already_exist
         false,
         false,
         None,
+        None,
     )
     .await
     .unwrap();
@@ -648,6 +659,7 @@ async fn test_infer_loop_reroutes_if_false_back_edge_to_loop() {
         false,
         false,
         None,
+        None,
     )
     .await
     .unwrap();
@@ -722,6 +734,7 @@ async fn test_infer_loop_removes_stray_endloop_forward_edge_when_loop_done_exist
         &sample_tools(),
         false,
         false,
+        None,
         None,
     )
     .await
@@ -828,6 +841,7 @@ async fn test_unknown_step_type_skipped_not_fatal() {
         false,
         false,
         None,
+        None,
     )
     .await
     .unwrap();
@@ -856,6 +870,7 @@ async fn test_malformed_node_missing_fields_skipped() {
         &sample_tools(),
         false,
         false,
+        None,
         None,
     )
     .await
@@ -889,6 +904,7 @@ async fn test_malformed_edge_unknown_output_type_skipped() {
         false,
         false,
         None,
+        None,
     )
     .await
     .unwrap();
@@ -918,6 +934,7 @@ async fn test_malformed_flat_step_skipped() {
         &sample_tools(),
         false,
         false,
+        None,
         None,
     )
     .await

--- a/crates/clickweave-llm/src/planner/tests/patch.rs
+++ b/crates/clickweave-llm/src/planner/tests/patch.rs
@@ -15,6 +15,7 @@ fn test_patcher_prompt_includes_node_arguments() {
             value: Some("Signal".into()),
             bring_to_front: true,
             app_kind: clickweave_core::AppKind::Native,
+            chrome_profile_id: None,
         }),
         Position { x: 0.0, y: 0.0 },
     );
@@ -283,6 +284,7 @@ async fn test_patch_adds_loop() {
             value: Some("Calculator".into()),
             bring_to_front: true,
             app_kind: clickweave_core::AppKind::Native,
+            chrome_profile_id: None,
         }),
         "Focus Calculator",
     );
@@ -338,6 +340,7 @@ fn test_mixed_add_and_add_nodes_warns_and_skips_flat() {
             value: Some("Calculator".to_string()),
             bring_to_front: true,
             app_kind: clickweave_core::AppKind::Native,
+            chrome_profile_id: None,
         }),
         "Focus Calculator",
     );

--- a/crates/clickweave-llm/src/planner/tests/plan.rs
+++ b/crates/clickweave-llm/src/planner/tests/plan.rs
@@ -18,6 +18,7 @@ async fn test_plan_focus_screenshot_click() {
         false,
         false,
         None,
+        None,
     )
     .await
     .unwrap();
@@ -52,10 +53,17 @@ async fn test_plan_with_code_fence_wrapping() {
 ]}
 ```"#;
     let mock = MockBackend::single(response);
-    let result =
-        plan_workflow_with_backend(&mock, "Type hello", &sample_tools(), false, false, None)
-            .await
-            .unwrap();
+    let result = plan_workflow_with_backend(
+        &mock,
+        "Type hello",
+        &sample_tools(),
+        false,
+        false,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
 
     assert_eq!(result.workflow.nodes.len(), 1);
     assert!(matches!(
@@ -78,6 +86,7 @@ async fn test_plan_agent_steps_filtered_when_disabled() {
         false,
         false,
         None,
+        None,
     )
     .await
     .unwrap();
@@ -99,6 +108,7 @@ async fn test_plan_agent_steps_kept_when_enabled() {
         &sample_tools(),
         false,
         true,
+        None,
         None,
     )
     .await
@@ -124,6 +134,7 @@ async fn test_repair_pass_fixes_invalid_json() {
         false,
         false,
         None,
+        None,
     )
     .await
     .unwrap();
@@ -145,6 +156,7 @@ async fn test_repair_pass_fails_after_max_attempts() {
         false,
         false,
         None,
+        None,
     )
     .await;
 
@@ -156,8 +168,16 @@ async fn test_repair_pass_fails_after_max_attempts() {
 async fn test_plan_empty_steps_returns_error() {
     let response = r#"{"steps": []}"#;
     let mock = MockBackend::single(response);
-    let result =
-        plan_workflow_with_backend(&mock, "Do nothing", &sample_tools(), false, false, None).await;
+    let result = plan_workflow_with_backend(
+        &mock,
+        "Do nothing",
+        &sample_tools(),
+        false,
+        false,
+        None,
+        None,
+    )
+    .await;
 
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("no steps"));
@@ -200,6 +220,7 @@ async fn test_plan_calculator_loop_scenario() {
         &sample_tools(),
         false,
         false,
+        None,
         None,
     )
     .await

--- a/crates/clickweave-llm/src/planner/tests/unit.rs
+++ b/crates/clickweave-llm/src/planner/tests/unit.rs
@@ -69,7 +69,7 @@ fn test_planner_prompt_includes_tools() {
             "parameters": {}
         }
     })];
-    let prompt = planner_system_prompt(&tools, false, false, None);
+    let prompt = planner_system_prompt(&tools, false, false, None, None);
     assert!(prompt.contains("click"));
     assert!(prompt.contains("Tool"));
     assert!(!prompt.contains("step_type\": \"AiTransform\""));
@@ -78,14 +78,14 @@ fn test_planner_prompt_includes_tools() {
 
 #[test]
 fn test_planner_system_prompt_with_all_features() {
-    let prompt = planner_system_prompt(&[], true, true, None);
+    let prompt = planner_system_prompt(&[], true, true, None, None);
     assert!(prompt.contains("AiTransform"));
     assert!(prompt.contains("AiStep"));
 }
 
 #[test]
 fn test_planner_prompt_includes_control_flow() {
-    let prompt = planner_system_prompt(&[], false, false, None);
+    let prompt = planner_system_prompt(&[], false, false, None, None);
     assert!(
         prompt.contains("Loop"),
         "Prompt should mention Loop step type"

--- a/src-tauri/src/commands/assistant.rs
+++ b/src-tauri/src/commands/assistant.rs
@@ -35,6 +35,8 @@ pub async fn assistant_chat(
         handle.lock().unwrap().abort = None;
     }
 
+    let chrome_profiles = super::chrome_profiles::get_store(&app).load_profiles();
+
     let emit_handle = app.clone();
     let join_handle = tokio::task::spawn(async move {
         let tools = fetch_mcp_tool_schemas().await?;
@@ -50,6 +52,12 @@ pub async fn assistant_chat(
             let _ = emit_handle.emit("assistant://repairing", (attempt, max));
         };
 
+        let profiles_ref = if chrome_profiles.len() > 1 {
+            Some(chrome_profiles.as_slice())
+        } else {
+            None
+        };
+
         let result = clickweave_llm::planner::assistant_chat(
             &request.workflow,
             &request.user_message,
@@ -61,6 +69,7 @@ pub async fn assistant_chat(
             request.allow_agent_steps,
             (request.max_repair_attempts as usize).min(10),
             Some(&on_repair),
+            profiles_ref,
         )
         .await
         .map_err(|e| CommandError::llm(format!("Assistant chat failed: {}", e)))?;

--- a/src-tauri/src/commands/chrome_profiles.rs
+++ b/src-tauri/src/commands/chrome_profiles.rs
@@ -3,7 +3,7 @@ use super::types::AppDataDir;
 use clickweave_core::chrome_profiles::{ChromeProfile, ChromeProfileStore};
 use tauri::Manager;
 
-fn get_store(app: &tauri::AppHandle) -> ChromeProfileStore {
+pub(super) fn get_store(app: &tauri::AppHandle) -> ChromeProfileStore {
     let app_data = app.state::<AppDataDir>();
     ChromeProfileStore::new(app_data.0.join("chrome-profiles"))
 }

--- a/src-tauri/src/commands/executor.rs
+++ b/src-tauri/src/commands/executor.rs
@@ -77,25 +77,9 @@ pub async fn run_workflow(app: tauri::AppHandle, request: RunRequest) -> Result<
     let cancel_token = CancellationToken::new();
     let executor_token = cancel_token.clone();
 
-    let chrome_profile_path = {
+    let chrome_profiles_dir = {
         let app_data = app.state::<super::types::AppDataDir>();
-        let profiles_dir = app_data.0.join("chrome-profiles");
-        let store = clickweave_core::chrome_profiles::ChromeProfileStore::new(profiles_dir);
-        match request.chrome_profile_id {
-            Some(id) => Some(store.profile_path(&id)),
-            None => {
-                // Best-effort: resolve default profile for Chrome 136+ compat.
-                // Failures are non-fatal — Chrome may still work (older versions)
-                // or the workflow may not use Chrome at all.
-                match store.ensure_profiles() {
-                    Ok(ps) => ps.into_iter().next().map(|p| store.profile_path(&p.id)),
-                    Err(e) => {
-                        warn!("Chrome profile setup failed (non-fatal): {e}");
-                        None
-                    }
-                }
-            }
-        }
+        app_data.0.join("chrome-profiles")
     };
 
     let task_handle = tauri::async_runtime::spawn(async move {
@@ -110,7 +94,7 @@ pub async fn run_workflow(app: tauri::AppHandle, request: RunRequest) -> Result<
             event_tx,
             storage,
             executor_token,
-            chrome_profile_path,
+            chrome_profiles_dir,
         );
         executor.run(cmd_rx).await;
     });

--- a/src-tauri/src/commands/planner.rs
+++ b/src-tauri/src/commands/planner.rs
@@ -15,9 +15,20 @@ pub(crate) async fn fetch_mcp_tool_schemas() -> Result<Vec<serde_json::Value>, C
 
 #[tauri::command]
 #[specta::specta]
-pub async fn plan_workflow(request: PlanRequest) -> Result<PlanResponse, CommandError> {
+pub async fn plan_workflow(
+    app: tauri::AppHandle,
+    request: PlanRequest,
+) -> Result<PlanResponse, CommandError> {
     let tools = fetch_mcp_tool_schemas().await?;
     let planner_config = request.planner.into_llm_config(None);
+
+    let chrome_profiles = super::chrome_profiles::get_store(&app).load_profiles();
+
+    let profiles_ref = if chrome_profiles.len() > 1 {
+        Some(chrome_profiles.as_slice())
+    } else {
+        None
+    };
 
     let result = clickweave_llm::planner::plan_workflow(
         &request.intent,
@@ -25,6 +36,7 @@ pub async fn plan_workflow(request: PlanRequest) -> Result<PlanResponse, Command
         &tools,
         request.allow_ai_transforms,
         request.allow_agent_steps,
+        profiles_ref,
     )
     .await
     .map_err(|e| CommandError::llm(format!("Planning failed: {}", e)))?;

--- a/src-tauri/src/commands/types.rs
+++ b/src-tauri/src/commands/types.rs
@@ -95,8 +95,6 @@ pub struct RunRequest {
     /// Planner LLM used for supervision in Test mode.
     pub planner: Option<EndpointConfig>,
     pub execution_mode: ExecutionMode,
-    /// Chrome profile ID for persistent browser sessions.
-    pub chrome_profile_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -73,7 +73,7 @@ function App() {
     })),
   );
 
-  const { plannerConfig, agentConfig, vlmConfig, vlmEnabled, maxRepairAttempts, hoverDwellThreshold, selectedChromeProfileId, chromeProfileConfigured } = useStore(
+  const { plannerConfig, agentConfig, vlmConfig, vlmEnabled, maxRepairAttempts, hoverDwellThreshold } = useStore(
     useShallow((s) => ({
       plannerConfig: s.plannerConfig,
       agentConfig: s.agentConfig,
@@ -81,8 +81,6 @@ function App() {
       vlmEnabled: s.vlmEnabled,
       maxRepairAttempts: s.maxRepairAttempts,
       hoverDwellThreshold: s.hoverDwellThreshold,
-      selectedChromeProfileId: s.selectedChromeProfileId,
-      chromeProfileConfigured: s.chromeProfileConfigured,
     })),
   );
 
@@ -114,7 +112,6 @@ function App() {
   const setVlmEnabled = useStore((s) => s.setVlmEnabled);
   const setMaxRepairAttempts = useStore((s) => s.setMaxRepairAttempts);
   const setHoverDwellThreshold = useStore((s) => s.setHoverDwellThreshold);
-  const setSelectedChromeProfileId = useStore((s) => s.setSelectedChromeProfileId);
   const setExecutionMode = useStore((s) => s.setExecutionMode);
   const supervisionRespond = useStore((s) => s.supervisionRespond);
   const runWorkflow = useStore((s) => s.runWorkflow);
@@ -182,15 +179,6 @@ function App() {
       />
 
       <div className="flex flex-1 flex-col overflow-hidden">
-        {!chromeProfileConfigured && (
-          <div className="border-b border-amber-700 bg-amber-900/50 px-4 py-2 text-sm text-amber-200">
-            Chrome profile not configured.{" "}
-            <button onClick={() => setShowSettings(true)} className="underline">
-              Go to Settings
-            </button>{" "}
-            and click Configure to set up your browser sessions.
-          </div>
-        )}
         <VerdictBar />
 
         <div className="relative flex flex-1 overflow-hidden">
@@ -318,7 +306,6 @@ function App() {
         vlmEnabled={vlmEnabled}
         maxRepairAttempts={maxRepairAttempts}
         hoverDwellThreshold={hoverDwellThreshold}
-        selectedChromeProfileId={selectedChromeProfileId}
         onClose={() => setShowSettings(false)}
         onPlannerConfigChange={setPlannerConfig}
         onAgentConfigChange={setAgentConfig}
@@ -326,7 +313,6 @@ function App() {
         onVlmEnabledChange={setVlmEnabled}
         onMaxRepairAttemptsChange={setMaxRepairAttempts}
         onHoverDwellThresholdChange={setHoverDwellThreshold}
-        onSelectedChromeProfileIdChange={setSelectedChromeProfileId}
       />
 
       <VerdictModal />

--- a/ui/src/bindings.ts
+++ b/ui/src/bindings.ts
@@ -372,7 +372,7 @@ export type ExecutionMode = "Test" | "Run"
 export type FindImageParams = { template_image: string | null; threshold: number; max_results: number }
 export type FindTextParams = { search_text: string; match_mode: MatchMode; scope: string | null; select_result: string | null }
 export type FocusMethod = "WindowId" | "AppName" | "Pid"
-export type FocusWindowParams = { method: FocusMethod; value: string | null; bring_to_front: boolean; app_kind?: AppKind }
+export type FocusWindowParams = { method: FocusMethod; value: string | null; bring_to_front: boolean; app_kind?: AppKind; chrome_profile_id?: string | null }
 export type HoverParams = { target: ClickTarget | null; template_image?: string | null; x: number | null; y: number | null; dwell_ms: number }
 export type IfParams = { condition: Condition }
 export type ImportedAsset = { relative_path: string; absolute_path: string }
@@ -426,11 +426,7 @@ export type RunRequest = { workflow: Workflow; project_path: string | null; agen
 /**
  * Planner LLM used for supervision in Test mode.
  */
-planner: EndpointConfig | null; execution_mode: ExecutionMode; 
-/**
- * Chrome profile ID for persistent browser sessions.
- */
-chrome_profile_id: string | null }
+planner: EndpointConfig | null; execution_mode: ExecutionMode }
 export type RunStatus = "Ok" | "Failed" | "Stopped"
 export type RunsQuery = { project_path: string | null; workflow_id: string; workflow_name: string; node_name: string }
 /**

--- a/ui/src/components/SettingsModal.tsx
+++ b/ui/src/components/SettingsModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import type { ChromeProfile } from "../bindings";
 import { commands } from "../bindings";
 import type { EndpointConfig } from "../store/useAppStore";
@@ -12,7 +12,6 @@ interface SettingsModalProps {
   vlmEnabled: boolean;
   maxRepairAttempts: number;
   hoverDwellThreshold: number;
-  selectedChromeProfileId: string | null;
   onClose: () => void;
   onPlannerConfigChange: (config: EndpointConfig) => void;
   onAgentConfigChange: (config: EndpointConfig) => void;
@@ -20,7 +19,6 @@ interface SettingsModalProps {
   onVlmEnabledChange: (enabled: boolean) => void;
   onMaxRepairAttemptsChange: (n: number) => void;
   onHoverDwellThresholdChange: (ms: number) => void;
-  onSelectedChromeProfileIdChange: (id: string) => void;
 }
 
 const inputClass =
@@ -86,30 +84,24 @@ function ConfigSection({
   );
 }
 
-function ChromeProfileSection({
-  selectedProfileId,
-  onProfileChange,
-}: {
-  selectedProfileId: string | null;
-  onProfileChange: (id: string) => void;
-}) {
+function ChromeProfileSection() {
   const [profiles, setProfiles] = useState<ChromeProfile[]>([]);
   const [loading, setLoading] = useState(false);
+  const [selectedProfileId, setSelectedProfileId] = useState<string | null>(null);
   const [newName, setNewName] = useState("");
   const [showNewInput, setShowNewInput] = useState(false);
-  const selectedProfileIdRef = useRef(selectedProfileId);
-  selectedProfileIdRef.current = selectedProfileId;
-  const onProfileChangeRef = useRef(onProfileChange);
-  onProfileChangeRef.current = onProfileChange;
 
   const fetchProfiles = async () => {
     setLoading(true);
     const result = await commands.listChromeProfiles();
     if (result.status === "ok") {
       setProfiles(result.data);
-      if (!selectedProfileIdRef.current && result.data.length > 0) {
-        onProfileChangeRef.current(result.data[0].id);
-      }
+      setSelectedProfileId((prev) => {
+        if (!prev && result.data.length > 0) {
+          return result.data[0].id;
+        }
+        return prev;
+      });
     }
     setLoading(false);
   };
@@ -123,7 +115,7 @@ function ChromeProfileSection({
     if (!newName.trim()) return;
     const result = await commands.createChromeProfile(newName.trim());
     if (result.status === "ok") {
-      onProfileChange(result.data.id);
+      setSelectedProfileId(result.data.id);
       setNewName("");
       setShowNewInput(false);
       fetchProfiles();
@@ -146,7 +138,7 @@ function ChromeProfileSection({
       <div className="flex items-center gap-2">
         <select
           value={selectedProfileId ?? ""}
-          onChange={(e) => onProfileChange(e.target.value)}
+          onChange={(e) => setSelectedProfileId(e.target.value)}
           disabled={loading || profiles.length === 0}
           className={inputClass}
         >
@@ -206,7 +198,6 @@ export function SettingsModal({
   vlmEnabled,
   maxRepairAttempts,
   hoverDwellThreshold,
-  selectedChromeProfileId,
   onClose,
   onPlannerConfigChange,
   onAgentConfigChange,
@@ -214,7 +205,6 @@ export function SettingsModal({
   onVlmEnabledChange,
   onMaxRepairAttemptsChange,
   onHoverDwellThresholdChange,
-  onSelectedChromeProfileIdChange,
 }: SettingsModalProps) {
   return (
     <Modal open={open} onClose={onClose} className="w-[480px] max-h-[90vh] overflow-y-auto rounded-lg border border-[var(--border)] bg-[var(--bg-panel)] shadow-xl">
@@ -305,10 +295,7 @@ export function SettingsModal({
             </div>
           </div>
 
-          <ChromeProfileSection
-            selectedProfileId={selectedChromeProfileId}
-            onProfileChange={onSelectedChromeProfileIdChange}
-          />
+          <ChromeProfileSection />
 
           <div>
             <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">

--- a/ui/src/store/settings.ts
+++ b/ui/src/store/settings.ts
@@ -9,7 +9,6 @@ export interface PersistedSettings {
   vlmEnabled: boolean;
   maxRepairAttempts: number;
   hoverDwellThreshold: number;
-  selectedChromeProfileId: string | null;
 }
 
 const SETTINGS_DEFAULTS: PersistedSettings = {
@@ -19,7 +18,6 @@ const SETTINGS_DEFAULTS: PersistedSettings = {
   vlmEnabled: DEFAULT_VLM_ENABLED,
   maxRepairAttempts: 3,
   hoverDwellThreshold: 2000,
-  selectedChromeProfileId: null,
 };
 
 export async function loadSettings(): Promise<PersistedSettings> {
@@ -35,7 +33,6 @@ export async function loadSettings(): Promise<PersistedSettings> {
   const vlmEnabled = await store.get<boolean>("vlmEnabled");
   const maxRepairAttempts = await store.get<number>("maxRepairAttempts");
   const hoverDwellThreshold = await store.get<number>("hoverDwellThreshold");
-  const selectedChromeProfileId = await store.get<string | null>("selectedChromeProfileId");
   return {
     plannerConfig: plannerConfig ?? fallback,
     agentConfig: agentConfig ?? fallback,
@@ -43,7 +40,6 @@ export async function loadSettings(): Promise<PersistedSettings> {
     vlmEnabled: vlmEnabled ?? SETTINGS_DEFAULTS.vlmEnabled,
     maxRepairAttempts: maxRepairAttempts ?? SETTINGS_DEFAULTS.maxRepairAttempts,
     hoverDwellThreshold: hoverDwellThreshold ?? SETTINGS_DEFAULTS.hoverDwellThreshold,
-    selectedChromeProfileId: selectedChromeProfileId ?? SETTINGS_DEFAULTS.selectedChromeProfileId,
   };
 }
 

--- a/ui/src/store/slices/executionSlice.ts
+++ b/ui/src/store/slices/executionSlice.ts
@@ -51,7 +51,7 @@ export const createExecutionSlice: StateCreator<StoreState, [], [], ExecutionSli
   },
 
   runWorkflow: async () => {
-    const { workflow, projectPath, agentConfig, vlmConfig, vlmEnabled, plannerConfig, executionMode, selectedChromeProfileId, pushLog } = get();
+    const { workflow, projectPath, agentConfig, vlmConfig, vlmEnabled, plannerConfig, executionMode, pushLog } = get();
 
     const graphErrors = validateSingleGraph(workflow.nodes, workflow.edges);
     if (graphErrors.length > 0) {
@@ -68,7 +68,6 @@ export const createExecutionSlice: StateCreator<StoreState, [], [], ExecutionSli
       vlm: vlmEnabled ? toEndpoint(vlmConfig) : null,
       planner: toEndpoint(plannerConfig),
       execution_mode: executionMode,
-      chrome_profile_id: selectedChromeProfileId,
     };
     const result = await commands.runWorkflow(request);
     if (result.status === "error") {

--- a/ui/src/store/slices/settingsSlice.ts
+++ b/ui/src/store/slices/settingsSlice.ts
@@ -12,8 +12,6 @@ export interface SettingsSlice {
   vlmEnabled: boolean;
   maxRepairAttempts: number;
   hoverDwellThreshold: number;
-  selectedChromeProfileId: string | null;
-  chromeProfileConfigured: boolean;
   _settingsLoaded: boolean;
 
   loadSettingsFromDisk: () => void;
@@ -23,7 +21,6 @@ export interface SettingsSlice {
   setVlmEnabled: (enabled: boolean) => void;
   setMaxRepairAttempts: (n: number) => void;
   setHoverDwellThreshold: (ms: number) => void;
-  setSelectedChromeProfileId: (id: string) => void;
 }
 
 function persistSetting<K extends keyof PersistedSettings>(
@@ -50,8 +47,6 @@ export const createSettingsSlice: StateCreator<StoreState, [], [], SettingsSlice
   vlmEnabled: DEFAULT_VLM_ENABLED,
   maxRepairAttempts: 3,
   hoverDwellThreshold: 2000,
-  selectedChromeProfileId: null,
-  chromeProfileConfigured: true,
   _settingsLoaded: false,
 
   loadSettingsFromDisk: () => {
@@ -66,8 +61,6 @@ export const createSettingsSlice: StateCreator<StoreState, [], [], SettingsSlice
           vlmEnabled: s.vlmEnabled,
           maxRepairAttempts: clampInt(s.maxRepairAttempts, 0, 10, 3),
           hoverDwellThreshold: clampInt(s.hoverDwellThreshold, 100, 10000, 2000),
-          selectedChromeProfileId: s.selectedChromeProfileId,
-          chromeProfileConfigured: s.selectedChromeProfileId != null,
         });
       })
       .catch((e) => console.error("Failed to load settings:", e));
@@ -79,9 +72,4 @@ export const createSettingsSlice: StateCreator<StoreState, [], [], SettingsSlice
   setVlmEnabled: (enabled) => persistSetting("vlmEnabled", enabled, set),
   setMaxRepairAttempts: (n) => persistSetting("maxRepairAttempts", clampInt(n, 0, 10, 3), set),
   setHoverDwellThreshold: (ms) => persistSetting("hoverDwellThreshold", clampInt(ms, 100, 10000, 2000), set),
-  setSelectedChromeProfileId: (id) => {
-    if (id === get().selectedChromeProfileId) return;
-    persistSetting("selectedChromeProfileId", id, set);
-    set({ chromeProfileConfigured: true });
-  },
 });


### PR DESCRIPTION
## Summary

- Move Chrome profile selection from a single workflow-level setting to individual `launch_app` nodes
- Executor resolves profiles per-node via `ChromeProfileStore` instead of a single `chrome_profile_path`
- Planner prompt injects available profiles so the LLM can assign them explicitly
- Frontend settings UI becomes a profile admin panel; runtime selection is per-node

## Test Plan

### Scenario 1: Single-profile workflow (no explicit profile)
- [ ] Create a workflow with a `launch_app` Chrome node (no `chrome_profile` argument)
- [ ] Run the workflow
- [ ] Verify Chrome launches with the first available profile (or auto-created "Profile 1" on fresh install)

### Scenario 2: Multi-profile workflow
- [x] In Settings, create two Chrome profiles (e.g., "Work" and "Personal") and configure each (log into different accounts)
- [x] Ask the planner: "Open Chrome with my Work profile, go to gmail.com, then open Chrome with my Personal profile, go to gmail.com"
- [x] Verify the generated workflow has two `launch_app` nodes with `chrome_profile: "Work"` and `chrome_profile: "Personal"` respectively
- [x] Run the workflow and verify each Chrome instance opens with the correct logged-in account