### PR TITLE
refactor(walkthrough): extract CDP injected JS into standalone files

### DIFF
--- a/crates/clickweave-core/src/walkthrough/cdp_scripts/check_and_reinject.js
+++ b/crates/clickweave-core/src/walkthrough/cdp_scripts/check_and_reinject.js
@@ -1,0 +1,25 @@
+  if (d.__cw_listener) return 'alive';
+  d.__cw_clicks = [];
+  d.__cw_handler = (e) => {
+    const el = e.target.closest(INTERACTIVE) || e.target.closest('[aria-label]') || e.target;
+    let text = accessibleText(el);
+    if (!text) text = findFallbackText(el);
+    const { parentRole, parentName } = findParentRoleAndName(el);
+    d.__cw_clicks.push({
+      ts: Date.now(),
+      tagName: el.tagName,
+      role: el.getAttribute('role') || TAG_ROLES[el.tagName] || null,
+      ariaLabel: el.ariaLabel || el.getAttribute('aria-label') || null,
+      textContent: text || null,
+      title: el.title || el.closest('[title]')?.title || null,
+      value: el.value || null,
+      href: el.closest('a')?.href || null,
+      id: el.id || null,
+      className: el.className || null,
+      parentRole: parentRole,
+      parentName: parentName,
+    });
+  };
+  d.__cw_listener = (e) => d.__cw_handler(e);
+  d.addEventListener('click', d.__cw_listener, true);
+  return 'reinjected';

--- a/crates/clickweave-core/src/walkthrough/cdp_scripts/click_listener.js
+++ b/crates/clickweave-core/src/walkthrough/cdp_scripts/click_listener.js
@@ -1,0 +1,26 @@
+  d.__cw_clicks = [];
+  d.__cw_handler = (e) => {
+    const el = e.target.closest(INTERACTIVE) || e.target.closest('[aria-label]') || e.target;
+    let text = accessibleText(el);
+    if (!text) text = findFallbackText(el);
+    const { parentRole, parentName } = findParentRoleAndName(el);
+    d.__cw_clicks.push({
+      ts: Date.now(),
+      tagName: el.tagName,
+      role: el.getAttribute('role') || TAG_ROLES[el.tagName] || null,
+      ariaLabel: el.ariaLabel || el.getAttribute('aria-label') || null,
+      textContent: text || null,
+      title: el.title || el.closest('[title]')?.title || null,
+      value: el.value || null,
+      href: el.closest('a')?.href || null,
+      id: el.id || null,
+      className: el.className || null,
+      parentRole: parentRole,
+      parentName: parentName,
+    });
+  };
+  if (d.__cw_listener) {
+    d.removeEventListener('click', d.__cw_listener, true);
+  }
+  d.__cw_listener = (e) => d.__cw_handler(e);
+  d.addEventListener('click', d.__cw_listener, true);

--- a/crates/clickweave-core/src/walkthrough/cdp_scripts/common.js
+++ b/crates/clickweave-core/src/walkthrough/cdp_scripts/common.js
@@ -1,0 +1,59 @@
+  const d = document;
+  const TAG_ROLES = {BUTTON:'button',A:'link',INPUT:'textbox',SELECT:'combobox',TEXTAREA:'textbox'};
+  const INTERACTIVE = '[role="button"],[role="link"],[role="menuitem"],[role="menuitemcheckbox"],[role="menuitemradio"],[role="tab"],[role="treeitem"],[role="option"],[role="checkbox"],[role="radio"],[role="switch"],[role="textbox"],[role="combobox"],[role="searchbox"],[role="slider"],[role="spinbutton"],a,button,select,textarea,input,[tabindex]:not([tabindex="-1"])';
+  function accessibleText(node) {
+    const a = node.ariaLabel || node.getAttribute('aria-label');
+    if (a) return a;
+    const lb = node.getAttribute('aria-labelledby');
+    if (lb) {
+      const t = lb.split(/\s+/).map(id => document.getElementById(id)?.textContent?.trim() || '').filter(Boolean).join(' ');
+      if (t) return t.substring(0, 200);
+    }
+    if (node.title) return node.title;
+    if (node.alt) return node.alt;
+    if (node.placeholder) return node.placeholder;
+    if ((node.tagName === 'svg' || node.tagName === 'SVG') || (node.namespaceURI === 'http://www.w3.org/2000/svg' && node.tagName === 'svg')) {
+      const st = node.querySelector('title');
+      if (st?.textContent) return st.textContent.trim().substring(0, 200);
+    }
+    let t = '';
+    for (const ch of node.childNodes) {
+      if (ch.nodeType === 3) { t += ch.textContent; continue; }
+      if (ch.nodeType === 1 && ch.getAttribute('aria-hidden') !== 'true') {
+        const sub = accessibleText(ch);
+        if (sub && t) t += ' ';
+        t += sub;
+      }
+    }
+    return t.trim().substring(0, 200);
+  }
+  function findFallbackText(el) {
+    let p = el.parentElement;
+    while (p && p !== d.documentElement) {
+      const la = p.ariaLabel || p.getAttribute('aria-label');
+      if (la) return la;
+      const lb = p.getAttribute('aria-labelledby');
+      if (lb) {
+        const r = lb.split(/\s+/).map(id => document.getElementById(id)?.textContent?.trim() || '').filter(Boolean).join(' ');
+        if (r) return r;
+      }
+      if (p.title) return p.title;
+      p = p.parentElement;
+    }
+    return '';
+  }
+  function findParentRoleAndName(el) {
+    let p = el.parentElement;
+    while (p && p !== d.documentElement) {
+      const r = p.getAttribute('role');
+      const a = p.ariaLabel || p.getAttribute('aria-label');
+      if (r || a) {
+        return {
+          parentRole: r || null,
+          parentName: a || accessibleText(p).substring(0, 200) || null,
+        };
+      }
+      p = p.parentElement;
+    }
+    return { parentRole: null, parentName: null };
+  }

--- a/crates/clickweave-core/src/walkthrough/cdp_scripts/hover_listener.js
+++ b/crates/clickweave-core/src/walkthrough/cdp_scripts/hover_listener.js
@@ -1,0 +1,53 @@
+  d.__cw_hovers = [];
+  d.__cw_hover_cx = 0;
+  d.__cw_hover_cy = 0;
+  d.__cw_hover_enter_sx = 0;
+  d.__cw_hover_enter_sy = 0;
+  d.__cw_hover_lastEl = null;
+  d.__cw_hover_enterTime = 0;
+  const MIN_DWELL = __CW_MIN_DWELL__;
+  if (d.__cw_hover_mousemove) {
+    d.removeEventListener('mousemove', d.__cw_hover_mousemove, true);
+  }
+  d.__cw_hover_mousemove = (e) => {
+    d.__cw_hover_cx = e.clientX;
+    d.__cw_hover_cy = e.clientY;
+  };
+  d.addEventListener('mousemove', d.__cw_hover_mousemove, true);
+  d.__cw_hover_flush = () => {
+    const el = d.__cw_hover_lastEl;
+    const enter = d.__cw_hover_enterTime;
+    if (!el || !enter) return;
+    const now = Date.now();
+    if ((now - enter) < MIN_DWELL) return;
+    let text = accessibleText(el);
+    if (!text) text = findFallbackText(el);
+    const { parentRole, parentName } = findParentRoleAndName(el);
+    d.__cw_hovers.push({
+      ts: enter,
+      dwellMs: now - enter,
+      x: d.__cw_hover_enter_sx,
+      y: d.__cw_hover_enter_sy,
+      tagName: el.tagName,
+      role: el.getAttribute('role') || TAG_ROLES[el.tagName] || null,
+      ariaLabel: el.ariaLabel || el.getAttribute('aria-label') || null,
+      textContent: text || null,
+      href: el.closest('a')?.href || null,
+      parentRole: parentRole,
+      parentName: parentName,
+    });
+    d.__cw_hover_lastEl = null;
+    d.__cw_hover_enterTime = 0;
+  };
+  if (d.__cw_hover_interval) clearInterval(d.__cw_hover_interval);
+  d.__cw_hover_interval = setInterval(() => {
+    const raw = d.elementFromPoint(d.__cw_hover_cx, d.__cw_hover_cy);
+    if (!raw) { d.__cw_hover_lastEl = null; d.__cw_hover_enterTime = 0; return; }
+    const el = raw.closest(INTERACTIVE) || raw.closest('[aria-label]') || raw;
+    if (el === d.__cw_hover_lastEl) return;
+    d.__cw_hover_flush();
+    d.__cw_hover_lastEl = el;
+    d.__cw_hover_enterTime = Date.now();
+    d.__cw_hover_enter_sx = d.__cw_hover_cx + window.screenX;
+    d.__cw_hover_enter_sy = d.__cw_hover_cy + window.screenY;
+  }, 100);

--- a/crates/clickweave-core/src/walkthrough/cdp_scripts/retrieve_click.js
+++ b/crates/clickweave-core/src/walkthrough/cdp_scripts/retrieve_click.js
@@ -1,0 +1,4 @@
+() => {
+  if (!Array.isArray(document.__cw_clicks)) return null;
+  return document.__cw_clicks.shift() || null;
+}

--- a/crates/clickweave-core/src/walkthrough/cdp_scripts/retrieve_hovers.js
+++ b/crates/clickweave-core/src/walkthrough/cdp_scripts/retrieve_hovers.js
@@ -1,0 +1,6 @@
+() => {
+  if (!Array.isArray(document.__cw_hovers)) return [];
+  const h = document.__cw_hovers;
+  document.__cw_hovers = [];
+  return h;
+}

--- a/crates/clickweave-core/src/walkthrough/cdp_scripts/stop_hover.js
+++ b/crates/clickweave-core/src/walkthrough/cdp_scripts/stop_hover.js
@@ -1,0 +1,6 @@
+() => {
+  const d = document;
+  if (d.__cw_hover_interval) { clearInterval(d.__cw_hover_interval); d.__cw_hover_interval = null; }
+  if (d.__cw_hover_flush) { d.__cw_hover_flush(); d.__cw_hover_flush = null; }
+  if (d.__cw_hover_mousemove) { d.removeEventListener('mousemove', d.__cw_hover_mousemove, true); d.__cw_hover_mousemove = null; }
+}

--- a/crates/clickweave-core/src/walkthrough/session.rs
+++ b/crates/clickweave-core/src/walkthrough/session.rs
@@ -20,9 +20,9 @@ use super::types::{
 /// and click queue remain accessible regardless of which world runs the
 /// injection or retrieval.
 ///
-/// The body is assembled at compile time from [`cdp_scripts/common.js`]
+/// The body is assembled at compile time from `cdp_scripts/common.js`
 /// (shared `TAG_ROLES` / `INTERACTIVE` / `accessibleText` helpers) and
-/// [`cdp_scripts/click_listener.js`] (the listener-specific logic).
+/// `cdp_scripts/click_listener.js` (the listener-specific logic).
 pub const CDP_CLICK_LISTENER_JS: &str = concat!(
     "() => {\n",
     include_str!("cdp_scripts/common.js"),
@@ -36,8 +36,8 @@ pub const CDP_RETRIEVE_CLICK_JS: &str = include_str!("cdp_scripts/retrieve_click
 /// JavaScript to check if the click listener is still alive; re-inject if lost.
 /// Returns `"reinjected"` if it was re-injected, `"alive"` otherwise.
 ///
-/// Body assembled from [`cdp_scripts/common.js`] and
-/// [`cdp_scripts/check_and_reinject.js`].
+/// Body assembled from `cdp_scripts/common.js` and
+/// `cdp_scripts/check_and_reinject.js`.
 pub const CDP_CHECK_AND_REINJECT_JS: &str = concat!(
     "() => {\n",
     include_str!("cdp_scripts/common.js"),
@@ -60,8 +60,8 @@ pub const CDP_CHECK_AND_REINJECT_JS: &str = concat!(
 /// Contains a `__CW_MIN_DWELL__` placeholder that must be replaced with
 /// the actual minimum dwell threshold (in milliseconds) before injection.
 ///
-/// Body assembled from [`cdp_scripts/common.js`] and
-/// [`cdp_scripts/hover_listener.js`].
+/// Body assembled from `cdp_scripts/common.js` and
+/// `cdp_scripts/hover_listener.js`.
 pub const CDP_HOVER_LISTENER_JS: &str = concat!(
     "() => {\n",
     include_str!("cdp_scripts/common.js"),

--- a/crates/clickweave-core/src/walkthrough/session.rs
+++ b/crates/clickweave-core/src/walkthrough/session.rs
@@ -19,182 +19,31 @@ use super::types::{
 /// shared across all JS execution contexts, so the listener, handler,
 /// and click queue remain accessible regardless of which world runs the
 /// injection or retrieval.
-pub const CDP_CLICK_LISTENER_JS: &str = r#"() => {
-  const d = document;
-  d.__cw_clicks = [];
-  const TAG_ROLES = {BUTTON:'button',A:'link',INPUT:'textbox',SELECT:'combobox',TEXTAREA:'textbox'};
-  const INTERACTIVE = '[role="button"],[role="link"],[role="menuitem"],[role="menuitemcheckbox"],[role="menuitemradio"],[role="tab"],[role="treeitem"],[role="option"],[role="checkbox"],[role="radio"],[role="switch"],[role="textbox"],[role="combobox"],[role="searchbox"],[role="slider"],[role="spinbutton"],a,button,select,textarea,input,[tabindex]:not([tabindex="-1"])';
-  function accessibleText(node) {
-    const a = node.ariaLabel || node.getAttribute('aria-label');
-    if (a) return a;
-    const lb = node.getAttribute('aria-labelledby');
-    if (lb) {
-      const t = lb.split(/\s+/).map(id => document.getElementById(id)?.textContent?.trim() || '').filter(Boolean).join(' ');
-      if (t) return t.substring(0, 200);
-    }
-    if (node.title) return node.title;
-    if (node.alt) return node.alt;
-    if (node.placeholder) return node.placeholder;
-    if ((node.tagName === 'svg' || node.tagName === 'SVG') || (node.namespaceURI === 'http://www.w3.org/2000/svg' && node.tagName === 'svg')) {
-      const st = node.querySelector('title');
-      if (st?.textContent) return st.textContent.trim().substring(0, 200);
-    }
-    let t = '';
-    for (const ch of node.childNodes) {
-      if (ch.nodeType === 3) { t += ch.textContent; continue; }
-      if (ch.nodeType === 1 && ch.getAttribute('aria-hidden') !== 'true') {
-        const sub = accessibleText(ch);
-        if (sub && t) t += ' ';
-        t += sub;
-      }
-    }
-    return t.trim().substring(0, 200);
-  }
-  d.__cw_handler = (e) => {
-    const el = e.target.closest(INTERACTIVE) || e.target.closest('[aria-label]') || e.target;
-    let text = accessibleText(el);
-    if (!text) {
-      let p = el.parentElement;
-      while (p && p !== d.documentElement) {
-        const la = p.ariaLabel || p.getAttribute('aria-label');
-        if (la) { text = la; break; }
-        const lb = p.getAttribute('aria-labelledby');
-        if (lb) {
-          const r = lb.split(/\s+/).map(id => document.getElementById(id)?.textContent?.trim() || '').filter(Boolean).join(' ');
-          if (r) { text = r; break; }
-        }
-        if (p.title) { text = p.title; break; }
-        p = p.parentElement;
-      }
-    }
-    let parentRole = null;
-    let parentName = null;
-    {
-      let p = el.parentElement;
-      while (p && p !== d.documentElement) {
-        const r = p.getAttribute('role');
-        const a = p.ariaLabel || p.getAttribute('aria-label');
-        if (r || a) {
-          parentRole = r || null;
-          parentName = a || accessibleText(p).substring(0, 200) || null;
-          break;
-        }
-        p = p.parentElement;
-      }
-    }
-    d.__cw_clicks.push({
-      ts: Date.now(),
-      tagName: el.tagName,
-      role: el.getAttribute('role') || TAG_ROLES[el.tagName] || null,
-      ariaLabel: el.ariaLabel || el.getAttribute('aria-label') || null,
-      textContent: text || null,
-      title: el.title || el.closest('[title]')?.title || null,
-      value: el.value || null,
-      href: el.closest('a')?.href || null,
-      id: el.id || null,
-      className: el.className || null,
-      parentRole: parentRole,
-      parentName: parentName,
-    });
-  };
-  if (d.__cw_listener) {
-    d.removeEventListener('click', d.__cw_listener, true);
-  }
-  d.__cw_listener = (e) => d.__cw_handler(e);
-  d.addEventListener('click', d.__cw_listener, true);
-}"#;
+///
+/// The body is assembled at compile time from [`cdp_scripts/common.js`]
+/// (shared `TAG_ROLES` / `INTERACTIVE` / `accessibleText` helpers) and
+/// [`cdp_scripts/click_listener.js`] (the listener-specific logic).
+pub const CDP_CLICK_LISTENER_JS: &str = concat!(
+    "() => {\n",
+    include_str!("cdp_scripts/common.js"),
+    include_str!("cdp_scripts/click_listener.js"),
+    "}",
+);
 
 /// JavaScript to retrieve and remove the oldest click from the queue.
-pub const CDP_RETRIEVE_CLICK_JS: &str = r#"() => {
-  if (!Array.isArray(document.__cw_clicks)) return null;
-  return document.__cw_clicks.shift() || null;
-}"#;
+pub const CDP_RETRIEVE_CLICK_JS: &str = include_str!("cdp_scripts/retrieve_click.js");
 
 /// JavaScript to check if the click listener is still alive; re-inject if lost.
 /// Returns `"reinjected"` if it was re-injected, `"alive"` otherwise.
-pub const CDP_CHECK_AND_REINJECT_JS: &str = r#"() => {
-  const d = document;
-  if (d.__cw_listener) return 'alive';
-  d.__cw_clicks = [];
-  const TAG_ROLES = {BUTTON:'button',A:'link',INPUT:'textbox',SELECT:'combobox',TEXTAREA:'textbox'};
-  const INTERACTIVE = '[role="button"],[role="link"],[role="menuitem"],[role="menuitemcheckbox"],[role="menuitemradio"],[role="tab"],[role="treeitem"],[role="option"],[role="checkbox"],[role="radio"],[role="switch"],[role="textbox"],[role="combobox"],[role="searchbox"],[role="slider"],[role="spinbutton"],a,button,select,textarea,input,[tabindex]:not([tabindex="-1"])';
-  function accessibleText(node) {
-    const a = node.ariaLabel || node.getAttribute('aria-label');
-    if (a) return a;
-    const lb = node.getAttribute('aria-labelledby');
-    if (lb) {
-      const t = lb.split(/\s+/).map(id => document.getElementById(id)?.textContent?.trim() || '').filter(Boolean).join(' ');
-      if (t) return t.substring(0, 200);
-    }
-    if (node.title) return node.title;
-    if (node.alt) return node.alt;
-    if (node.placeholder) return node.placeholder;
-    if ((node.tagName === 'svg' || node.tagName === 'SVG') || (node.namespaceURI === 'http://www.w3.org/2000/svg' && node.tagName === 'svg')) {
-      const st = node.querySelector('title');
-      if (st?.textContent) return st.textContent.trim().substring(0, 200);
-    }
-    let t = '';
-    for (const ch of node.childNodes) {
-      if (ch.nodeType === 3) { t += ch.textContent; continue; }
-      if (ch.nodeType === 1 && ch.getAttribute('aria-hidden') !== 'true') {
-        const sub = accessibleText(ch);
-        if (sub && t) t += ' ';
-        t += sub;
-      }
-    }
-    return t.trim().substring(0, 200);
-  }
-  d.__cw_handler = (e) => {
-    const el = e.target.closest(INTERACTIVE) || e.target.closest('[aria-label]') || e.target;
-    let text = accessibleText(el);
-    if (!text) {
-      let p = el.parentElement;
-      while (p && p !== d.documentElement) {
-        const la = p.ariaLabel || p.getAttribute('aria-label');
-        if (la) { text = la; break; }
-        const lb = p.getAttribute('aria-labelledby');
-        if (lb) {
-          const r = lb.split(/\s+/).map(id => document.getElementById(id)?.textContent?.trim() || '').filter(Boolean).join(' ');
-          if (r) { text = r; break; }
-        }
-        if (p.title) { text = p.title; break; }
-        p = p.parentElement;
-      }
-    }
-    let parentRole = null;
-    let parentName = null;
-    {
-      let p = el.parentElement;
-      while (p && p !== d.documentElement) {
-        const r = p.getAttribute('role');
-        const a = p.ariaLabel || p.getAttribute('aria-label');
-        if (r || a) {
-          parentRole = r || null;
-          parentName = a || accessibleText(p).substring(0, 200) || null;
-          break;
-        }
-        p = p.parentElement;
-      }
-    }
-    d.__cw_clicks.push({
-      ts: Date.now(),
-      tagName: el.tagName,
-      role: el.getAttribute('role') || TAG_ROLES[el.tagName] || null,
-      ariaLabel: el.ariaLabel || el.getAttribute('aria-label') || null,
-      textContent: text || null,
-      title: el.title || el.closest('[title]')?.title || null,
-      value: el.value || null,
-      href: el.closest('a')?.href || null,
-      id: el.id || null,
-      className: el.className || null,
-      parentRole: parentRole,
-      parentName: parentName,
-    });
-  };
-  d.__cw_listener = (e) => d.__cw_handler(e);
-  d.addEventListener('click', d.__cw_listener, true);
-  return 'reinjected';
-}"#;
+///
+/// Body assembled from [`cdp_scripts/common.js`] and
+/// [`cdp_scripts/check_and_reinject.js`].
+pub const CDP_CHECK_AND_REINJECT_JS: &str = concat!(
+    "() => {\n",
+    include_str!("cdp_scripts/common.js"),
+    include_str!("cdp_scripts/check_and_reinject.js"),
+    "}",
+);
 
 /// JavaScript hover listener injected into CDP-enabled apps.
 /// Tracks which interactive element the cursor is over using a polling
@@ -210,136 +59,24 @@ pub const CDP_CHECK_AND_REINJECT_JS: &str = r#"() => {
 ///
 /// Contains a `__CW_MIN_DWELL__` placeholder that must be replaced with
 /// the actual minimum dwell threshold (in milliseconds) before injection.
-pub const CDP_HOVER_LISTENER_JS: &str = r#"() => {
-  const d = document;
-  d.__cw_hovers = [];
-  d.__cw_hover_cx = 0;
-  d.__cw_hover_cy = 0;
-  d.__cw_hover_enter_sx = 0;
-  d.__cw_hover_enter_sy = 0;
-  const TAG_ROLES = {BUTTON:'button',A:'link',INPUT:'textbox',SELECT:'combobox',TEXTAREA:'textbox'};
-  const INTERACTIVE = '[role="button"],[role="link"],[role="menuitem"],[role="menuitemcheckbox"],[role="menuitemradio"],[role="tab"],[role="treeitem"],[role="option"],[role="checkbox"],[role="radio"],[role="switch"],[role="textbox"],[role="combobox"],[role="searchbox"],[role="slider"],[role="spinbutton"],a,button,select,textarea,input,[tabindex]:not([tabindex="-1"])';
-  function accessibleText(node) {
-    const a = node.ariaLabel || node.getAttribute('aria-label');
-    if (a) return a;
-    const lb = node.getAttribute('aria-labelledby');
-    if (lb) {
-      const t = lb.split(/\s+/).map(id => document.getElementById(id)?.textContent?.trim() || '').filter(Boolean).join(' ');
-      if (t) return t.substring(0, 200);
-    }
-    if (node.title) return node.title;
-    if (node.alt) return node.alt;
-    if (node.placeholder) return node.placeholder;
-    if ((node.tagName === 'svg' || node.tagName === 'SVG') || (node.namespaceURI === 'http://www.w3.org/2000/svg' && node.tagName === 'svg')) {
-      const st = node.querySelector('title');
-      if (st?.textContent) return st.textContent.trim().substring(0, 200);
-    }
-    let t = '';
-    for (const ch of node.childNodes) {
-      if (ch.nodeType === 3) { t += ch.textContent; continue; }
-      if (ch.nodeType === 1 && ch.getAttribute('aria-hidden') !== 'true') {
-        const sub = accessibleText(ch);
-        if (sub && t) t += ' ';
-        t += sub;
-      }
-    }
-    return t.trim().substring(0, 200);
-  }
-  d.__cw_hover_lastEl = null;
-  d.__cw_hover_enterTime = 0;
-  const MIN_DWELL = __CW_MIN_DWELL__;
-  if (d.__cw_hover_mousemove) {
-    d.removeEventListener('mousemove', d.__cw_hover_mousemove, true);
-  }
-  d.__cw_hover_mousemove = (e) => {
-    d.__cw_hover_cx = e.clientX;
-    d.__cw_hover_cy = e.clientY;
-  };
-  d.addEventListener('mousemove', d.__cw_hover_mousemove, true);
-  d.__cw_hover_flush = () => {
-    const el = d.__cw_hover_lastEl;
-    const enter = d.__cw_hover_enterTime;
-    if (!el || !enter) return;
-    const now = Date.now();
-    if ((now - enter) < MIN_DWELL) return;
-    let text = accessibleText(el);
-    if (!text) {
-      let p = el.parentElement;
-      while (p && p !== d.documentElement) {
-        const la = p.ariaLabel || p.getAttribute('aria-label');
-        if (la) { text = la; break; }
-        const lb = p.getAttribute('aria-labelledby');
-        if (lb) {
-          const r = lb.split(/\s+/).map(id => document.getElementById(id)?.textContent?.trim() || '').filter(Boolean).join(' ');
-          if (r) { text = r; break; }
-        }
-        if (p.title) { text = p.title; break; }
-        p = p.parentElement;
-      }
-    }
-    let parentRole = null;
-    let parentName = null;
-    {
-      let p = el.parentElement;
-      while (p && p !== d.documentElement) {
-        const r = p.getAttribute('role');
-        const a = p.ariaLabel || p.getAttribute('aria-label');
-        if (r || a) {
-          parentRole = r || null;
-          parentName = a || accessibleText(p).substring(0, 200) || null;
-          break;
-        }
-        p = p.parentElement;
-      }
-    }
-    d.__cw_hovers.push({
-      ts: enter,
-      dwellMs: now - enter,
-      x: d.__cw_hover_enter_sx,
-      y: d.__cw_hover_enter_sy,
-      tagName: el.tagName,
-      role: el.getAttribute('role') || TAG_ROLES[el.tagName] || null,
-      ariaLabel: el.ariaLabel || el.getAttribute('aria-label') || null,
-      textContent: text || null,
-      href: el.closest('a')?.href || null,
-      parentRole: parentRole,
-      parentName: parentName,
-    });
-    d.__cw_hover_lastEl = null;
-    d.__cw_hover_enterTime = 0;
-  };
-  if (d.__cw_hover_interval) clearInterval(d.__cw_hover_interval);
-  d.__cw_hover_interval = setInterval(() => {
-    const raw = d.elementFromPoint(d.__cw_hover_cx, d.__cw_hover_cy);
-    if (!raw) { d.__cw_hover_lastEl = null; d.__cw_hover_enterTime = 0; return; }
-    const el = raw.closest(INTERACTIVE) || raw.closest('[aria-label]') || raw;
-    if (el === d.__cw_hover_lastEl) return;
-    d.__cw_hover_flush();
-    d.__cw_hover_lastEl = el;
-    d.__cw_hover_enterTime = Date.now();
-    d.__cw_hover_enter_sx = d.__cw_hover_cx + window.screenX;
-    d.__cw_hover_enter_sy = d.__cw_hover_cy + window.screenY;
-  }, 100);
-}"#;
+///
+/// Body assembled from [`cdp_scripts/common.js`] and
+/// [`cdp_scripts/hover_listener.js`].
+pub const CDP_HOVER_LISTENER_JS: &str = concat!(
+    "() => {\n",
+    include_str!("cdp_scripts/common.js"),
+    include_str!("cdp_scripts/hover_listener.js"),
+    "}",
+);
 
 /// JavaScript to retrieve and clear all collected hover data from the
 /// injected hover listener.  Returns the full array and resets it.
-pub const CDP_RETRIEVE_HOVERS_JS: &str = r#"() => {
-  if (!Array.isArray(document.__cw_hovers)) return [];
-  const h = document.__cw_hovers;
-  document.__cw_hovers = [];
-  return h;
-}"#;
+pub const CDP_RETRIEVE_HOVERS_JS: &str = include_str!("cdp_scripts/retrieve_hovers.js");
 
 /// JavaScript to stop the hover listener's polling interval and remove
 /// the mousemove handler, flushing any pending dwell that exceeds the
 /// minimum threshold.
-pub const CDP_STOP_HOVER_JS: &str = r#"() => {
-  const d = document;
-  if (d.__cw_hover_interval) { clearInterval(d.__cw_hover_interval); d.__cw_hover_interval = null; }
-  if (d.__cw_hover_flush) { d.__cw_hover_flush(); d.__cw_hover_flush = null; }
-  if (d.__cw_hover_mousemove) { d.removeEventListener('mousemove', d.__cw_hover_mousemove, true); d.__cw_hover_mousemove = null; }
-}"#;
+pub const CDP_STOP_HOVER_JS: &str = include_str!("cdp_scripts/stop_hover.js");
 
 // ---------------------------------------------------------------------------
 // Pure session helpers

--- a/ui/src/cdp-scripts/check_and_reinject.test.ts
+++ b/ui/src/cdp-scripts/check_and_reinject.test.ts
@@ -1,34 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { loadCheckAndReinject, loadClickListener } from "./loader";
-
-type CdpDocument = Document & {
-    __cw_clicks?: unknown[];
-    __cw_listener?: EventListener;
-    __cw_handler?: EventListener;
-};
-
-function cdpDoc(): CdpDocument {
-    return document as CdpDocument;
-}
-
-function resetCdpState() {
-    const d = cdpDoc();
-    if (d.__cw_listener) {
-        d.removeEventListener("click", d.__cw_listener, true);
-    }
-    delete d.__cw_clicks;
-    delete d.__cw_listener;
-    delete d.__cw_handler;
-    document.body.innerHTML = "";
-}
+import { cdpDoc, resetClickState } from "./test-helpers";
 
 describe("CDP check_and_reinject.js", () => {
     beforeEach(() => {
-        resetCdpState();
+        resetClickState();
     });
 
     afterEach(() => {
-        resetCdpState();
+        resetClickState();
     });
 
     it("returns 'alive' and leaves state untouched when the listener exists", () => {

--- a/ui/src/cdp-scripts/check_and_reinject.test.ts
+++ b/ui/src/cdp-scripts/check_and_reinject.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadCheckAndReinject, loadClickListener } from "./loader";
+
+type CdpDocument = Document & {
+    __cw_clicks?: unknown[];
+    __cw_listener?: EventListener;
+    __cw_handler?: EventListener;
+};
+
+function cdpDoc(): CdpDocument {
+    return document as CdpDocument;
+}
+
+function resetCdpState() {
+    const d = cdpDoc();
+    if (d.__cw_listener) {
+        d.removeEventListener("click", d.__cw_listener, true);
+    }
+    delete d.__cw_clicks;
+    delete d.__cw_listener;
+    delete d.__cw_handler;
+    document.body.innerHTML = "";
+}
+
+describe("CDP check_and_reinject.js", () => {
+    beforeEach(() => {
+        resetCdpState();
+    });
+
+    afterEach(() => {
+        resetCdpState();
+    });
+
+    it("returns 'alive' and leaves state untouched when the listener exists", () => {
+        loadClickListener()();
+        const queueBefore = cdpDoc().__cw_clicks;
+        const listenerBefore = cdpDoc().__cw_listener;
+
+        const result = loadCheckAndReinject()();
+
+        expect(result).toBe("alive");
+        expect(cdpDoc().__cw_clicks).toBe(queueBefore);
+        expect(cdpDoc().__cw_listener).toBe(listenerBefore);
+    });
+
+    it("returns 'reinjected' and installs a new listener when none exists", () => {
+        expect(cdpDoc().__cw_listener).toBeUndefined();
+
+        const result = loadCheckAndReinject()();
+
+        expect(result).toBe("reinjected");
+        expect(Array.isArray(cdpDoc().__cw_clicks)).toBe(true);
+        expect(typeof cdpDoc().__cw_listener).toBe("function");
+    });
+
+    it("the re-injected listener captures clicks like the original", () => {
+        document.body.innerHTML = `<button id="b" aria-label="Reinjected">Hi</button>`;
+        const result = loadCheckAndReinject()();
+        expect(result).toBe("reinjected");
+
+        document.getElementById("b")!.click();
+
+        const clicks = cdpDoc().__cw_clicks as Array<{ ariaLabel: string | null }>;
+        expect(clicks).toHaveLength(1);
+        expect(clicks[0].ariaLabel).toBe("Reinjected");
+    });
+});

--- a/ui/src/cdp-scripts/click_listener.test.ts
+++ b/ui/src/cdp-scripts/click_listener.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadClickListener, loadRetrieveClick } from "./loader";
+
+// Narrow the bits of `document` that the injected script stores on.
+type ClickEntry = {
+    ts: number;
+    tagName: string;
+    role: string | null;
+    ariaLabel: string | null;
+    textContent: string | null;
+    title: string | null;
+    value: string | null;
+    href: string | null;
+    id: string | null;
+    className: string | null;
+    parentRole: string | null;
+    parentName: string | null;
+};
+
+type CdpDocument = Document & {
+    __cw_clicks?: ClickEntry[];
+    __cw_listener?: EventListener;
+    __cw_handler?: EventListener;
+};
+
+function cdpDoc(): CdpDocument {
+    return document as CdpDocument;
+}
+
+function resetCdpState() {
+    const d = cdpDoc();
+    if (d.__cw_listener) {
+        d.removeEventListener("click", d.__cw_listener, true);
+    }
+    delete d.__cw_clicks;
+    delete d.__cw_listener;
+    delete d.__cw_handler;
+    document.body.innerHTML = "";
+}
+
+describe("CDP click_listener.js", () => {
+    beforeEach(() => {
+        resetCdpState();
+    });
+
+    afterEach(() => {
+        resetCdpState();
+    });
+
+    it("initializes the click queue and installs a capture-phase listener", () => {
+        loadClickListener()();
+
+        const d = cdpDoc();
+        expect(Array.isArray(d.__cw_clicks)).toBe(true);
+        expect(d.__cw_clicks).toHaveLength(0);
+        expect(typeof d.__cw_listener).toBe("function");
+        expect(typeof d.__cw_handler).toBe("function");
+    });
+
+    it("captures aria-label as textContent when clicking a button", () => {
+        document.body.innerHTML = `<button id="b" aria-label="Submit form"><span>Submit</span></button>`;
+        loadClickListener()();
+
+        document.getElementById("b")!.click();
+
+        const clicks = cdpDoc().__cw_clicks!;
+        expect(clicks).toHaveLength(1);
+        expect(clicks[0].tagName).toBe("BUTTON");
+        expect(clicks[0].role).toBe("button");
+        expect(clicks[0].ariaLabel).toBe("Submit form");
+        expect(clicks[0].textContent).toBe("Submit form");
+        expect(clicks[0].id).toBe("b");
+    });
+
+    it("falls back to visible text when no aria-label is set", () => {
+        document.body.innerHTML = `<button id="b">Click me</button>`;
+        loadClickListener()();
+
+        document.getElementById("b")!.click();
+
+        const clicks = cdpDoc().__cw_clicks!;
+        expect(clicks[0].textContent).toBe("Click me");
+        expect(clicks[0].ariaLabel).toBeNull();
+    });
+
+    it("resolves the nearest interactive ancestor when clicking a descendant", () => {
+        document.body.innerHTML = `
+            <button id="b" aria-label="Parent button">
+                <span id="inner"><i>icon</i></span>
+            </button>`;
+        loadClickListener()();
+
+        (document.getElementById("inner")!.firstElementChild as HTMLElement).click();
+
+        const clicks = cdpDoc().__cw_clicks!;
+        expect(clicks).toHaveLength(1);
+        expect(clicks[0].tagName).toBe("BUTTON");
+        expect(clicks[0].ariaLabel).toBe("Parent button");
+    });
+
+    it("walks up to a labelled ancestor when no text is found locally", () => {
+        // `span` with tabindex is interactive but has no visible text; ancestor
+        // div carries the aria-label that findFallbackText picks up.
+        document.body.innerHTML = `
+            <div aria-label="Outer label">
+                <span id="s" tabindex="0"></span>
+            </div>`;
+        loadClickListener()();
+
+        document.getElementById("s")!.click();
+
+        const clicks = cdpDoc().__cw_clicks!;
+        expect(clicks[0].textContent).toBe("Outer label");
+        expect(clicks[0].parentName).toBe("Outer label");
+    });
+
+    it("records parentRole/parentName from the nearest ancestor with role or label", () => {
+        document.body.innerHTML = `
+            <nav role="navigation" aria-label="Primary">
+                <a id="a" href="/x">Home</a>
+            </nav>`;
+        loadClickListener()();
+
+        document.getElementById("a")!.click();
+
+        const clicks = cdpDoc().__cw_clicks!;
+        expect(clicks[0].parentRole).toBe("navigation");
+        expect(clicks[0].parentName).toBe("Primary");
+    });
+
+    it("re-injecting replaces the previous listener (no duplicate clicks)", () => {
+        document.body.innerHTML = `<button id="b">Hi</button>`;
+        const inject = loadClickListener();
+        inject();
+        inject();
+
+        document.getElementById("b")!.click();
+
+        // Exactly one entry — the first listener was removed.
+        expect(cdpDoc().__cw_clicks).toHaveLength(1);
+    });
+
+    it("retrieve_click.js shifts the oldest entry off the queue", () => {
+        document.body.innerHTML = `<button id="b">Hi</button>`;
+        loadClickListener()();
+        document.getElementById("b")!.click();
+        document.getElementById("b")!.click();
+
+        const retrieve = loadRetrieveClick();
+        const first = retrieve() as ClickEntry | null;
+        const second = retrieve() as ClickEntry | null;
+        const third = retrieve() as ClickEntry | null;
+
+        expect(first?.tagName).toBe("BUTTON");
+        expect(second?.tagName).toBe("BUTTON");
+        expect(third).toBeNull();
+    });
+});

--- a/ui/src/cdp-scripts/click_listener.test.ts
+++ b/ui/src/cdp-scripts/click_listener.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { loadClickListener, loadRetrieveClick } from "./loader";
+import { cdpDoc, resetClickState } from "./test-helpers";
 
-// Narrow the bits of `document` that the injected script stores on.
 type ClickEntry = {
     ts: number;
     tagName: string;
@@ -17,34 +17,13 @@ type ClickEntry = {
     parentName: string | null;
 };
 
-type CdpDocument = Document & {
-    __cw_clicks?: ClickEntry[];
-    __cw_listener?: EventListener;
-    __cw_handler?: EventListener;
-};
-
-function cdpDoc(): CdpDocument {
-    return document as CdpDocument;
-}
-
-function resetCdpState() {
-    const d = cdpDoc();
-    if (d.__cw_listener) {
-        d.removeEventListener("click", d.__cw_listener, true);
-    }
-    delete d.__cw_clicks;
-    delete d.__cw_listener;
-    delete d.__cw_handler;
-    document.body.innerHTML = "";
-}
-
 describe("CDP click_listener.js", () => {
     beforeEach(() => {
-        resetCdpState();
+        resetClickState();
     });
 
     afterEach(() => {
-        resetCdpState();
+        resetClickState();
     });
 
     it("initializes the click queue and installs a capture-phase listener", () => {

--- a/ui/src/cdp-scripts/hover_listener.test.ts
+++ b/ui/src/cdp-scripts/hover_listener.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadHoverListener, loadStopHover } from "./loader";
+
+type HoverEntry = {
+    ts: number;
+    dwellMs: number;
+    x: number;
+    y: number;
+    tagName: string;
+    role: string | null;
+    ariaLabel: string | null;
+    textContent: string | null;
+    href: string | null;
+    parentRole: string | null;
+    parentName: string | null;
+};
+
+type CdpDocument = Document & {
+    __cw_hovers?: HoverEntry[];
+    __cw_hover_interval?: ReturnType<typeof setInterval> | null;
+    __cw_hover_mousemove?: EventListener | null;
+    __cw_hover_flush?: (() => void) | null;
+    __cw_hover_lastEl?: Element | null;
+    __cw_hover_enterTime?: number;
+    __cw_hover_cx?: number;
+    __cw_hover_cy?: number;
+};
+
+function cdpDoc(): CdpDocument {
+    return document as CdpDocument;
+}
+
+function resetCdpState() {
+    const d = cdpDoc();
+    if (d.__cw_hover_interval) {
+        clearInterval(d.__cw_hover_interval);
+    }
+    if (d.__cw_hover_mousemove) {
+        d.removeEventListener("mousemove", d.__cw_hover_mousemove, true);
+    }
+    delete d.__cw_hovers;
+    delete d.__cw_hover_interval;
+    delete d.__cw_hover_mousemove;
+    delete d.__cw_hover_flush;
+    delete d.__cw_hover_lastEl;
+    delete d.__cw_hover_enterTime;
+    delete d.__cw_hover_cx;
+    delete d.__cw_hover_cy;
+    document.body.innerHTML = "";
+}
+
+describe("CDP hover_listener.js", () => {
+    beforeEach(() => {
+        resetCdpState();
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        resetCdpState();
+    });
+
+    it("initializes hover state and registers mousemove + polling interval", () => {
+        loadHoverListener(500)();
+
+        const d = cdpDoc();
+        expect(Array.isArray(d.__cw_hovers)).toBe(true);
+        expect(d.__cw_hovers).toHaveLength(0);
+        expect(d.__cw_hover_cx).toBe(0);
+        expect(d.__cw_hover_cy).toBe(0);
+        expect(typeof d.__cw_hover_mousemove).toBe("function");
+        expect(typeof d.__cw_hover_flush).toBe("function");
+        expect(d.__cw_hover_interval).toBeTruthy();
+    });
+
+    it("mousemove updates the cached cursor position", () => {
+        loadHoverListener(500)();
+
+        document.dispatchEvent(
+            new MouseEvent("mousemove", { clientX: 42, clientY: 77, bubbles: true }),
+        );
+
+        const d = cdpDoc();
+        expect(d.__cw_hover_cx).toBe(42);
+        expect(d.__cw_hover_cy).toBe(77);
+    });
+
+    it("records a hover entry once dwell exceeds the minimum threshold", () => {
+        // jsdom does not implement elementFromPoint — stub it so the polling
+        // interval sees our synthetic element.
+        document.body.innerHTML = `
+            <button id="a" aria-label="Play">Play</button>
+            <button id="b" aria-label="Next">Next</button>`;
+        const a = document.getElementById("a")!;
+        const b = document.getElementById("b")!;
+        let current: Element = a;
+        document.elementFromPoint = ((_x: number, _y: number) => current) as Document["elementFromPoint"];
+
+        loadHoverListener(200)();
+
+        // Poll once: pointer enters button `a` (lastEl transitions from null -> a).
+        vi.advanceTimersByTime(100);
+        expect(cdpDoc().__cw_hover_lastEl).toBe(a);
+        expect(cdpDoc().__cw_hovers).toHaveLength(0);
+
+        // Accumulate dwell past the 200ms threshold, then transition to `b`;
+        // the transition flushes the dwell on `a`.
+        vi.advanceTimersByTime(250);
+        current = b;
+        vi.advanceTimersByTime(100);
+
+        const hovers = cdpDoc().__cw_hovers!;
+        expect(hovers).toHaveLength(1);
+        expect(hovers[0].tagName).toBe("BUTTON");
+        expect(hovers[0].ariaLabel).toBe("Play");
+        expect(hovers[0].textContent).toBe("Play");
+        expect(hovers[0].dwellMs).toBeGreaterThanOrEqual(200);
+    });
+
+    it("drops hovers that do not meet the minimum dwell threshold", () => {
+        document.body.innerHTML = `
+            <button id="a">A</button>
+            <button id="b">B</button>`;
+        const a = document.getElementById("a")!;
+        const b = document.getElementById("b")!;
+        let current: Element | null = a;
+        document.elementFromPoint = ((_x: number, _y: number) => current) as Document["elementFromPoint"];
+
+        loadHoverListener(500)();
+
+        vi.advanceTimersByTime(100);
+        expect(cdpDoc().__cw_hover_lastEl).toBe(a);
+
+        // Switch the pointer to `b` almost immediately — dwell on `a` is < 500ms.
+        vi.advanceTimersByTime(100);
+        current = b;
+        vi.advanceTimersByTime(100);
+
+        expect(cdpDoc().__cw_hovers).toHaveLength(0);
+        expect(cdpDoc().__cw_hover_lastEl).toBe(b);
+    });
+
+    it("stop_hover.js clears the interval and the mousemove handler", () => {
+        loadHoverListener(500)();
+        const d = cdpDoc();
+        expect(d.__cw_hover_interval).toBeTruthy();
+        expect(d.__cw_hover_mousemove).toBeTruthy();
+
+        loadStopHover()();
+
+        expect(d.__cw_hover_interval).toBeNull();
+        expect(d.__cw_hover_mousemove).toBeNull();
+        expect(d.__cw_hover_flush).toBeNull();
+    });
+
+    it("re-injecting removes the previous mousemove listener (no dup captures)", () => {
+        const inject = loadHoverListener(500);
+        inject();
+        const firstHandler = cdpDoc().__cw_hover_mousemove;
+        inject();
+        const secondHandler = cdpDoc().__cw_hover_mousemove;
+
+        expect(firstHandler).not.toBe(secondHandler);
+
+        // Dispatch one mousemove — only the latest handler should observe it.
+        document.dispatchEvent(
+            new MouseEvent("mousemove", { clientX: 10, clientY: 20, bubbles: true }),
+        );
+        expect(cdpDoc().__cw_hover_cx).toBe(10);
+        expect(cdpDoc().__cw_hover_cy).toBe(20);
+    });
+});

--- a/ui/src/cdp-scripts/hover_listener.test.ts
+++ b/ui/src/cdp-scripts/hover_listener.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadHoverListener, loadStopHover } from "./loader";
+import { cdpDoc, resetHoverState } from "./test-helpers";
 
 type HoverEntry = {
     ts: number;
@@ -15,49 +16,15 @@ type HoverEntry = {
     parentName: string | null;
 };
 
-type CdpDocument = Document & {
-    __cw_hovers?: HoverEntry[];
-    __cw_hover_interval?: ReturnType<typeof setInterval> | null;
-    __cw_hover_mousemove?: EventListener | null;
-    __cw_hover_flush?: (() => void) | null;
-    __cw_hover_lastEl?: Element | null;
-    __cw_hover_enterTime?: number;
-    __cw_hover_cx?: number;
-    __cw_hover_cy?: number;
-};
-
-function cdpDoc(): CdpDocument {
-    return document as CdpDocument;
-}
-
-function resetCdpState() {
-    const d = cdpDoc();
-    if (d.__cw_hover_interval) {
-        clearInterval(d.__cw_hover_interval);
-    }
-    if (d.__cw_hover_mousemove) {
-        d.removeEventListener("mousemove", d.__cw_hover_mousemove, true);
-    }
-    delete d.__cw_hovers;
-    delete d.__cw_hover_interval;
-    delete d.__cw_hover_mousemove;
-    delete d.__cw_hover_flush;
-    delete d.__cw_hover_lastEl;
-    delete d.__cw_hover_enterTime;
-    delete d.__cw_hover_cx;
-    delete d.__cw_hover_cy;
-    document.body.innerHTML = "";
-}
-
 describe("CDP hover_listener.js", () => {
     beforeEach(() => {
-        resetCdpState();
+        resetHoverState();
         vi.useFakeTimers();
     });
 
     afterEach(() => {
         vi.useRealTimers();
-        resetCdpState();
+        resetHoverState();
     });
 
     it("initializes hover state and registers mousemove + polling interval", () => {

--- a/ui/src/cdp-scripts/loader.ts
+++ b/ui/src/cdp-scripts/loader.ts
@@ -1,0 +1,55 @@
+// Helper that loads the CDP injected-JS scripts from the Rust crate so we
+// can test their observable behavior in jsdom.
+//
+// The scripts live in `crates/clickweave-core/src/walkthrough/cdp_scripts/`
+// and are assembled into a single evaluated function at Rust compile time
+// via `concat!(include_str!(...), ...)`.  To mirror that at test time we
+// import each file with Vite's `?raw` suffix and compose them the same way.
+
+import commonSrc from "../../../crates/clickweave-core/src/walkthrough/cdp_scripts/common.js?raw";
+import clickListenerSrc from "../../../crates/clickweave-core/src/walkthrough/cdp_scripts/click_listener.js?raw";
+import checkAndReinjectSrc from "../../../crates/clickweave-core/src/walkthrough/cdp_scripts/check_and_reinject.js?raw";
+import hoverListenerSrc from "../../../crates/clickweave-core/src/walkthrough/cdp_scripts/hover_listener.js?raw";
+import retrieveClickSrc from "../../../crates/clickweave-core/src/walkthrough/cdp_scripts/retrieve_click.js?raw";
+import retrieveHoversSrc from "../../../crates/clickweave-core/src/walkthrough/cdp_scripts/retrieve_hovers.js?raw";
+import stopHoverSrc from "../../../crates/clickweave-core/src/walkthrough/cdp_scripts/stop_hover.js?raw";
+
+/** Compose `common.js` + a listener body into a callable arrow function. */
+function composeWithCommon(bodySrc: string): () => unknown {
+    const src = `() => {\n${commonSrc}${bodySrc}}`;
+    // eslint-disable-next-line no-new-func
+    return new Function(`return (${src});`)() as () => unknown;
+}
+
+/** Wrap a standalone `() => {...}` script as a callable arrow function. */
+function composeStandalone(src: string): () => unknown {
+    // eslint-disable-next-line no-new-func
+    return new Function(`return (${src});`)() as () => unknown;
+}
+
+export function loadClickListener(): () => void {
+    return composeWithCommon(clickListenerSrc) as () => void;
+}
+
+export function loadCheckAndReinject(): () => string {
+    return composeWithCommon(checkAndReinjectSrc) as () => string;
+}
+
+export function loadHoverListener(minDwellMs: number): () => void {
+    const body = hoverListenerSrc.replace("__CW_MIN_DWELL__", String(minDwellMs));
+    return composeWithCommon(body) as () => void;
+}
+
+export function loadRetrieveClick(): () => unknown {
+    return composeStandalone(retrieveClickSrc);
+}
+
+export function loadRetrieveHovers(): () => unknown[] {
+    return composeStandalone(retrieveHoversSrc) as () => unknown[];
+}
+
+export function loadStopHover(): () => void {
+    return composeStandalone(stopHoverSrc) as () => void;
+}
+
+export const rawCommon = commonSrc;

--- a/ui/src/cdp-scripts/loader.ts
+++ b/ui/src/cdp-scripts/loader.ts
@@ -1,10 +1,6 @@
-// Helper that loads the CDP injected-JS scripts from the Rust crate so we
-// can test their observable behavior in jsdom.
-//
-// The scripts live in `crates/clickweave-core/src/walkthrough/cdp_scripts/`
-// and are assembled into a single evaluated function at Rust compile time
-// via `concat!(include_str!(...), ...)`.  To mirror that at test time we
-// import each file with Vite's `?raw` suffix and compose them the same way.
+// Load each CDP injected-JS script via Vite's `?raw` import and compose it
+// the same way Rust does at compile time, so vitest runs the exact bytes
+// that ship to the browser.
 
 import commonSrc from "../../../crates/clickweave-core/src/walkthrough/cdp_scripts/common.js?raw";
 import clickListenerSrc from "../../../crates/clickweave-core/src/walkthrough/cdp_scripts/click_listener.js?raw";
@@ -14,16 +10,12 @@ import retrieveClickSrc from "../../../crates/clickweave-core/src/walkthrough/cd
 import retrieveHoversSrc from "../../../crates/clickweave-core/src/walkthrough/cdp_scripts/retrieve_hovers.js?raw";
 import stopHoverSrc from "../../../crates/clickweave-core/src/walkthrough/cdp_scripts/stop_hover.js?raw";
 
-/** Compose `common.js` + a listener body into a callable arrow function. */
 function composeWithCommon(bodySrc: string): () => unknown {
     const src = `() => {\n${commonSrc}${bodySrc}}`;
-    // eslint-disable-next-line no-new-func
     return new Function(`return (${src});`)() as () => unknown;
 }
 
-/** Wrap a standalone `() => {...}` script as a callable arrow function. */
 function composeStandalone(src: string): () => unknown {
-    // eslint-disable-next-line no-new-func
     return new Function(`return (${src});`)() as () => unknown;
 }
 
@@ -51,5 +43,3 @@ export function loadRetrieveHovers(): () => unknown[] {
 export function loadStopHover(): () => void {
     return composeStandalone(stopHoverSrc) as () => void;
 }
-
-export const rawCommon = commonSrc;

--- a/ui/src/cdp-scripts/retrieve_click.test.ts
+++ b/ui/src/cdp-scripts/retrieve_click.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadRetrieveClick } from "./loader";
+
+type CdpDocument = Document & {
+    __cw_clicks?: unknown[];
+};
+
+function cdpDoc(): CdpDocument {
+    return document as CdpDocument;
+}
+
+describe("CDP retrieve_click.js", () => {
+    beforeEach(() => {
+        delete cdpDoc().__cw_clicks;
+    });
+
+    afterEach(() => {
+        delete cdpDoc().__cw_clicks;
+    });
+
+    it("returns null when the click queue has never been initialized", () => {
+        const retrieve = loadRetrieveClick();
+        expect(retrieve()).toBeNull();
+    });
+
+    it("returns null when the click queue is an empty array", () => {
+        cdpDoc().__cw_clicks = [];
+        const retrieve = loadRetrieveClick();
+        expect(retrieve()).toBeNull();
+    });
+
+    it("FIFO-shifts entries: first call returns the oldest entry", () => {
+        cdpDoc().__cw_clicks = [
+            { ts: 1, tagName: "FIRST" },
+            { ts: 2, tagName: "SECOND" },
+        ];
+        const retrieve = loadRetrieveClick();
+        expect(retrieve()).toMatchObject({ tagName: "FIRST" });
+        expect(retrieve()).toMatchObject({ tagName: "SECOND" });
+        expect(retrieve()).toBeNull();
+    });
+
+    it("mutates the queue in place (shift semantics)", () => {
+        cdpDoc().__cw_clicks = [{ ts: 1 }, { ts: 2 }];
+        loadRetrieveClick()();
+        expect(cdpDoc().__cw_clicks).toHaveLength(1);
+    });
+
+    it("returns null when the queue is not an array (e.g. has been clobbered)", () => {
+        (cdpDoc() as unknown as Record<string, unknown>).__cw_clicks = { bogus: true };
+        const retrieve = loadRetrieveClick();
+        expect(retrieve()).toBeNull();
+    });
+});

--- a/ui/src/cdp-scripts/retrieve_click.test.ts
+++ b/ui/src/cdp-scripts/retrieve_click.test.ts
@@ -1,13 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { loadRetrieveClick } from "./loader";
-
-type CdpDocument = Document & {
-    __cw_clicks?: unknown[];
-};
-
-function cdpDoc(): CdpDocument {
-    return document as CdpDocument;
-}
+import { cdpDoc } from "./test-helpers";
 
 describe("CDP retrieve_click.js", () => {
     beforeEach(() => {

--- a/ui/src/cdp-scripts/retrieve_hovers.test.ts
+++ b/ui/src/cdp-scripts/retrieve_hovers.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadRetrieveHovers } from "./loader";
+
+type CdpDocument = Document & {
+    __cw_hovers?: unknown[];
+};
+
+function cdpDoc(): CdpDocument {
+    return document as CdpDocument;
+}
+
+describe("CDP retrieve_hovers.js", () => {
+    beforeEach(() => {
+        delete cdpDoc().__cw_hovers;
+    });
+
+    afterEach(() => {
+        delete cdpDoc().__cw_hovers;
+    });
+
+    it("returns an empty array when the hover queue is uninitialized", () => {
+        expect(loadRetrieveHovers()()).toEqual([]);
+    });
+
+    it("returns the full queue and clears it atomically", () => {
+        const entries = [{ ts: 1 }, { ts: 2 }, { ts: 3 }];
+        cdpDoc().__cw_hovers = entries;
+
+        const result = loadRetrieveHovers()();
+
+        expect(result).toEqual(entries);
+        // Retrieval must reset the live queue so subsequent calls return an
+        // empty result (the injected hovers get drained once).
+        expect(cdpDoc().__cw_hovers).toEqual([]);
+        expect(loadRetrieveHovers()()).toEqual([]);
+    });
+
+    it("returns empty array when the queue field is not an array", () => {
+        (cdpDoc() as unknown as Record<string, unknown>).__cw_hovers = { not: "an array" };
+        expect(loadRetrieveHovers()()).toEqual([]);
+    });
+});

--- a/ui/src/cdp-scripts/retrieve_hovers.test.ts
+++ b/ui/src/cdp-scripts/retrieve_hovers.test.ts
@@ -1,13 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { loadRetrieveHovers } from "./loader";
-
-type CdpDocument = Document & {
-    __cw_hovers?: unknown[];
-};
-
-function cdpDoc(): CdpDocument {
-    return document as CdpDocument;
-}
+import { cdpDoc } from "./test-helpers";
 
 describe("CDP retrieve_hovers.js", () => {
     beforeEach(() => {

--- a/ui/src/cdp-scripts/stop_hover.test.ts
+++ b/ui/src/cdp-scripts/stop_hover.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadHoverListener, loadStopHover } from "./loader";
+
+type HoverEntry = {
+    ts: number;
+    dwellMs: number;
+    tagName: string;
+    textContent: string | null;
+};
+
+type CdpDocument = Document & {
+    __cw_hovers?: HoverEntry[];
+    __cw_hover_interval?: ReturnType<typeof setInterval> | null;
+    __cw_hover_mousemove?: EventListener | null;
+    __cw_hover_flush?: (() => void) | null;
+    __cw_hover_lastEl?: Element | null;
+    __cw_hover_enterTime?: number;
+    __cw_hover_cx?: number;
+    __cw_hover_cy?: number;
+};
+
+function cdpDoc(): CdpDocument {
+    return document as CdpDocument;
+}
+
+function resetCdpState() {
+    const d = cdpDoc();
+    if (d.__cw_hover_interval) {
+        clearInterval(d.__cw_hover_interval);
+    }
+    if (d.__cw_hover_mousemove) {
+        d.removeEventListener("mousemove", d.__cw_hover_mousemove, true);
+    }
+    delete d.__cw_hovers;
+    delete d.__cw_hover_interval;
+    delete d.__cw_hover_mousemove;
+    delete d.__cw_hover_flush;
+    delete d.__cw_hover_lastEl;
+    delete d.__cw_hover_enterTime;
+    delete d.__cw_hover_cx;
+    delete d.__cw_hover_cy;
+    document.body.innerHTML = "";
+}
+
+describe("CDP stop_hover.js", () => {
+    beforeEach(() => {
+        resetCdpState();
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        resetCdpState();
+    });
+
+    it("is a no-op when no hover listener was ever installed", () => {
+        // None of the `__cw_hover_*` fields exist — stop_hover must not throw.
+        expect(() => loadStopHover()()).not.toThrow();
+    });
+
+    it("flushes a pending hover that has exceeded the dwell threshold", () => {
+        document.body.innerHTML = `<button id="b" aria-label="Stopper">Stop</button>`;
+        const btn = document.getElementById("b")!;
+        document.elementFromPoint = ((_x: number, _y: number) => btn) as Document["elementFromPoint"];
+
+        loadHoverListener(100)();
+
+        // Poll once: pointer enters the button.
+        vi.advanceTimersByTime(100);
+        expect(cdpDoc().__cw_hover_lastEl).toBe(btn);
+
+        // Accumulate dwell beyond the 100ms threshold, then stop.
+        vi.advanceTimersByTime(200);
+
+        loadStopHover()();
+
+        const hovers = cdpDoc().__cw_hovers!;
+        expect(hovers).toHaveLength(1);
+        expect(hovers[0].tagName).toBe("BUTTON");
+        expect(hovers[0].textContent).toBe("Stopper");
+        expect(cdpDoc().__cw_hover_interval).toBeNull();
+        expect(cdpDoc().__cw_hover_mousemove).toBeNull();
+        expect(cdpDoc().__cw_hover_flush).toBeNull();
+    });
+
+    it("does not flush a hover that is below the dwell threshold", () => {
+        document.body.innerHTML = `<button id="b">Short</button>`;
+        const btn = document.getElementById("b")!;
+        document.elementFromPoint = ((_x: number, _y: number) => btn) as Document["elementFromPoint"];
+
+        loadHoverListener(500)();
+        vi.advanceTimersByTime(100); // pointer enters btn
+        vi.advanceTimersByTime(100); // only 100ms of dwell
+
+        loadStopHover()();
+
+        expect(cdpDoc().__cw_hovers).toHaveLength(0);
+    });
+});

--- a/ui/src/cdp-scripts/stop_hover.test.ts
+++ b/ui/src/cdp-scripts/stop_hover.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadHoverListener, loadStopHover } from "./loader";
+import { cdpDoc, resetHoverState } from "./test-helpers";
 
 type HoverEntry = {
     ts: number;
@@ -8,49 +9,15 @@ type HoverEntry = {
     textContent: string | null;
 };
 
-type CdpDocument = Document & {
-    __cw_hovers?: HoverEntry[];
-    __cw_hover_interval?: ReturnType<typeof setInterval> | null;
-    __cw_hover_mousemove?: EventListener | null;
-    __cw_hover_flush?: (() => void) | null;
-    __cw_hover_lastEl?: Element | null;
-    __cw_hover_enterTime?: number;
-    __cw_hover_cx?: number;
-    __cw_hover_cy?: number;
-};
-
-function cdpDoc(): CdpDocument {
-    return document as CdpDocument;
-}
-
-function resetCdpState() {
-    const d = cdpDoc();
-    if (d.__cw_hover_interval) {
-        clearInterval(d.__cw_hover_interval);
-    }
-    if (d.__cw_hover_mousemove) {
-        d.removeEventListener("mousemove", d.__cw_hover_mousemove, true);
-    }
-    delete d.__cw_hovers;
-    delete d.__cw_hover_interval;
-    delete d.__cw_hover_mousemove;
-    delete d.__cw_hover_flush;
-    delete d.__cw_hover_lastEl;
-    delete d.__cw_hover_enterTime;
-    delete d.__cw_hover_cx;
-    delete d.__cw_hover_cy;
-    document.body.innerHTML = "";
-}
-
 describe("CDP stop_hover.js", () => {
     beforeEach(() => {
-        resetCdpState();
+        resetHoverState();
         vi.useFakeTimers();
     });
 
     afterEach(() => {
         vi.useRealTimers();
-        resetCdpState();
+        resetHoverState();
     });
 
     it("is a no-op when no hover listener was ever installed", () => {

--- a/ui/src/cdp-scripts/test-helpers.ts
+++ b/ui/src/cdp-scripts/test-helpers.ts
@@ -1,0 +1,51 @@
+// Shared DOM-global shape and reset helpers for CDP injected-JS tests.
+// The injected scripts stash state on `document` under `__cw_*` keys — tests
+// narrow or widen as needed, but reset logic is identical across the suite.
+
+export type CdpDocument = Document & {
+    __cw_clicks?: unknown[];
+    __cw_listener?: EventListener;
+    __cw_handler?: EventListener;
+    __cw_hovers?: unknown[];
+    __cw_hover_interval?: ReturnType<typeof setInterval> | null;
+    __cw_hover_mousemove?: EventListener | null;
+    __cw_hover_flush?: (() => void) | null;
+    __cw_hover_lastEl?: Element | null;
+    __cw_hover_enterTime?: number;
+    __cw_hover_cx?: number;
+    __cw_hover_cy?: number;
+};
+
+export function cdpDoc(): CdpDocument {
+    return document as CdpDocument;
+}
+
+export function resetClickState(): void {
+    const d = cdpDoc();
+    if (d.__cw_listener) {
+        d.removeEventListener("click", d.__cw_listener, true);
+    }
+    delete d.__cw_clicks;
+    delete d.__cw_listener;
+    delete d.__cw_handler;
+    document.body.innerHTML = "";
+}
+
+export function resetHoverState(): void {
+    const d = cdpDoc();
+    if (d.__cw_hover_interval) {
+        clearInterval(d.__cw_hover_interval);
+    }
+    if (d.__cw_hover_mousemove) {
+        d.removeEventListener("mousemove", d.__cw_hover_mousemove, true);
+    }
+    delete d.__cw_hovers;
+    delete d.__cw_hover_interval;
+    delete d.__cw_hover_mousemove;
+    delete d.__cw_hover_flush;
+    delete d.__cw_hover_lastEl;
+    delete d.__cw_hover_enterTime;
+    delete d.__cw_hover_cx;
+    delete d.__cw_hover_cy;
+    document.body.innerHTML = "";
+}


### PR DESCRIPTION
## Summary

- Extract the six CDP injected-JS Rust string consts from `walkthrough/session.rs` into standalone `.js` files under `walkthrough/cdp_scripts/`, composed at compile time via `concat!(include_str!(...))`.
- Deduplicate the `accessibleText()`, `INTERACTIVE` tag list, and parent-traversal logic into `common.js`, concatenated into each listener IIFE.
- Add 28 vitest+jsdom tests that load the same `.js` bundles via Vite `?raw` imports and compose them the same way, so the bytes executed in the browser are the bytes under test.

## Test plan

- [x] `cargo test -p clickweave-core --lib` — 232 tests pass
- [x] `cd ui && npm test -- --run src/cdp-scripts` — 28 tests pass (6 files)
- [x] `cargo doc -p clickweave-core --no-deps` — no new warnings