### PR TITLE
test(agent): add cross-run integration coverage at Tauri/UI seam

### DIFF
--- a/crates/clickweave-engine/src/agent/tests/coordination.rs
+++ b/crates/clickweave-engine/src/agent/tests/coordination.rs
@@ -1,9 +1,8 @@
 //! Cross-task coordination integration tests.
 //!
-//! These exercise the `AgentChannels` contract end-to-end — a harness task
-//! plays the role the Tauri forwarders play in production, and the
-//! assertions verify the engine responds to realistic cross-task event
-//! sequences. See `issue-101-agent-integration-tests` for the scenarios.
+//! Each test plays the role the Tauri forwarders play in production so
+//! the engine's response to realistic cross-task event sequences is
+//! covered at the `AgentChannels` contract boundary.
 
 use super::{CapturingMockAgent, MockAgent, MockMcp};
 use crate::agent::loop_runner::AgentRunner;
@@ -13,15 +12,13 @@ use clickweave_llm::Message;
 use clickweave_mcp::{ToolCallResult, ToolContent};
 use serde_json::Value;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
 
 // ---------------------------------------------------------------------------
-// Test helpers
+// Shared test helpers
 // ---------------------------------------------------------------------------
 
-/// Build a successful CDP find-elements response with a single Submit button.
-/// Used as the standard "approval-gated" observation fixture.
 fn cdp_button_page(url: &str) -> ToolCallResult {
     ToolCallResult {
         content: vec![ToolContent::Text {
@@ -41,8 +38,6 @@ fn cdp_button_page(url: &str) -> ToolCallResult {
     }
 }
 
-/// Plain-text CDP find-elements response with zero matches.
-/// Used for native / no-CDP paths where elements are empty.
 fn cdp_empty_page() -> ToolCallResult {
     ToolCallResult {
         content: vec![ToolContent::Text {
@@ -57,20 +52,60 @@ fn cdp_empty_page() -> ToolCallResult {
     }
 }
 
+fn text_result(text: &str) -> ToolCallResult {
+    ToolCallResult {
+        content: vec![ToolContent::Text {
+            text: text.to_string(),
+        }],
+        is_error: None,
+    }
+}
+
+type ApprovalChannelTx = mpsc::Sender<(ApprovalRequest, oneshot::Sender<bool>)>;
+type ApprovalChannelRx = mpsc::Receiver<(ApprovalRequest, oneshot::Sender<bool>)>;
+
+fn approval_channel() -> (ApprovalChannelTx, ApprovalChannelRx) {
+    mpsc::channel(1)
+}
+
+/// Drain every pending approval request and answer `true`.
+fn spawn_auto_approver(mut rx: ApprovalChannelRx) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        while let Some((_req, resp_tx)) = rx.recv().await {
+            let _ = resp_tx.send(true);
+        }
+    })
+}
+
+/// Auto-approver that records the tool name of each request seen.
+fn spawn_recording_approver(
+    mut rx: ApprovalChannelRx,
+) -> (JoinHandle<()>, Arc<Mutex<Vec<String>>>) {
+    let seen: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let seen_clone = seen.clone();
+    let handle = tokio::spawn(async move {
+        while let Some((req, resp_tx)) = rx.recv().await {
+            seen_clone.lock().unwrap().push(req.tool_name.clone());
+            let _ = resp_tx.send(true);
+        }
+    });
+    (handle, seen)
+}
+
+fn drain_events(rx: &mut mpsc::Receiver<AgentEvent>) -> Vec<AgentEvent> {
+    let mut out = Vec::new();
+    while let Ok(ev) = rx.try_recv() {
+        out.push(ev);
+    }
+    out
+}
+
 // ---------------------------------------------------------------------------
 // Scenario 1: Stop during approval wait
-//
-// The Tauri approval forwarder's `AgentHandle::force_stop()` must drive the
-// engine to a `Rejected` outcome, not `ApprovalUnavailable`. The harness
-// below simulates the exact drop_on_cancel-vs-send_false difference:
-// dropping the oneshot sender surfaces as `ApprovalUnavailable`, while
-// explicitly sending `false` surfaces as `Rejected` → `Replan`.
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
 async fn stop_during_approval_wait_sends_rejection_not_channel_drop() {
-    // The LLM proposes a click that needs approval, then after the replan
-    // declares the goal done (so the run can reach a terminal state).
     let agent_llm = MockAgent::new(vec![
         MockAgent::tool_call_response("click", r#"{"x": 10, "y": 20}"#, "call_0"),
         MockAgent::done_response("Found another way after cancel"),
@@ -85,17 +120,13 @@ async fn stop_during_approval_wait_sends_rejection_not_channel_drop() {
     };
 
     let (event_tx, _event_rx) = mpsc::channel::<AgentEvent>(64);
-    let (approval_tx, mut approval_rx) =
-        mpsc::channel::<(ApprovalRequest, oneshot::Sender<bool>)>(1);
+    let (approval_tx, mut approval_rx) = approval_channel();
 
-    // Harness: mimic `AgentHandle::force_stop()` — receive the approval
-    // request, then instead of dropping the oneshot, send `false` on it
-    // (the fix) so the engine observes an explicit rejection and replans
-    // rather than tearing down with `ApprovalUnavailable`.
+    // Receive the approval request, then send `false` on the oneshot
+    // instead of dropping it — the engine must observe an explicit
+    // rejection (Replan) rather than ApprovalUnavailable.
     tokio::spawn(async move {
         if let Some((_req, resp_tx)) = approval_rx.recv().await {
-            // Simulate a brief approval-wait window.
-            tokio::time::sleep(Duration::from_millis(10)).await;
             let _ = resp_tx.send(false);
         }
     });
@@ -111,8 +142,6 @@ async fn stop_during_approval_wait_sends_rejection_not_channel_drop() {
         .await
         .unwrap();
 
-    // Explicit rejection must surface as Replan (the terminal state of the
-    // cancelled step), never as ApprovalUnavailable.
     assert!(
         matches!(state.steps[0].outcome, StepOutcome::Replan(_)),
         "Expected Replan after force_stop rejection, got {:?}",
@@ -129,18 +158,11 @@ async fn stop_during_approval_wait_sends_rejection_not_channel_drop() {
 }
 
 // ---------------------------------------------------------------------------
-// Scenario 2: Buffered events drained between runs do not leak
-//
-// The event forwarder in Tauri drains remaining events on cancel. The
-// engine-level contract is: whatever the forwarder sees on the event
-// channel is tagged with the run_id it began forwarding for. This test
-// demonstrates that two back-to-back runs each have their own event
-// streams — channel A's events cannot appear on channel B.
+// Scenario 2: Back-to-back runs do not leak events between channels
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
 async fn buffered_events_do_not_leak_between_runs() {
-    // Run A — produce several events, then let them sit in the buffer.
     let llm_a = MockAgent::new(vec![
         MockAgent::tool_call_response("click", r#"{"x": 1, "y": 2}"#, "call_a0"),
         MockAgent::done_response("run A done"),
@@ -148,19 +170,13 @@ async fn buffered_events_do_not_leak_between_runs() {
     let mcp_a = MockMcp::with_click_tool();
 
     let (event_tx_a, mut event_rx_a) = mpsc::channel::<AgentEvent>(64);
-    // Auto-approve so the run progresses without external coordination.
-    let (approval_tx_a, mut approval_rx_a) =
-        mpsc::channel::<(ApprovalRequest, oneshot::Sender<bool>)>(1);
-    tokio::spawn(async move {
-        while let Some((_req, resp_tx)) = approval_rx_a.recv().await {
-            let _ = resp_tx.send(true);
-        }
-    });
+    let (approval_tx_a, approval_rx_a) = approval_channel();
+    let approver_a = spawn_auto_approver(approval_rx_a);
 
     let mut runner_a = AgentRunner::new(&llm_a, AgentConfig::default())
         .with_events(event_tx_a)
         .with_approval(approval_tx_a);
-    let _ = runner_a
+    runner_a
         .run(
             "goal A".to_string(),
             clickweave_core::Workflow::new("A"),
@@ -170,27 +186,22 @@ async fn buffered_events_do_not_leak_between_runs() {
         )
         .await
         .unwrap();
+    approver_a.abort();
 
-    // Drain run A's events — all events collected here are tagged with
-    // run A's lifecycle (the channel is exclusively A's).
-    let mut run_a_events = Vec::new();
-    while let Ok(ev) = event_rx_a.try_recv() {
-        run_a_events.push(ev);
-    }
+    let run_a_events = drain_events(&mut event_rx_a);
     assert!(!run_a_events.is_empty(), "Run A must have produced events");
 
-    // Run B — fresh channels. Run A's channel is dropped; B's sender
-    // cannot carry A's history.
+    // Run B uses fresh channels — A's channel is already dropped, so
+    // B's receiver is physically isolated from A's history.
     let llm_b = MockAgent::new(vec![MockAgent::done_response("run B done")]);
     let mcp_b = MockMcp::with_click_tool();
 
     let (event_tx_b, mut event_rx_b) = mpsc::channel::<AgentEvent>(64);
-    let (approval_tx_b, _approval_rx_b) =
-        mpsc::channel::<(ApprovalRequest, oneshot::Sender<bool>)>(1);
+    let (approval_tx_b, _approval_rx_b) = approval_channel();
     let mut runner_b = AgentRunner::new(&llm_b, AgentConfig::default())
         .with_events(event_tx_b)
         .with_approval(approval_tx_b);
-    let _ = runner_b
+    runner_b
         .run(
             "goal B".to_string(),
             clickweave_core::Workflow::new("B"),
@@ -201,52 +212,29 @@ async fn buffered_events_do_not_leak_between_runs() {
         .await
         .unwrap();
 
-    // Collect run B's events. The count of B's events must match what B
-    // produced, with zero contamination from A (the channels are isolated
-    // so this is trivially true at the engine layer — we document the
-    // contract that Tauri's forwarder relies on).
-    let mut run_b_events = Vec::new();
-    while let Ok(ev) = event_rx_b.try_recv() {
-        run_b_events.push(ev);
-    }
-    // Both runs should have emitted GoalComplete. A's GoalComplete must
-    // have arrived on A's channel only.
-    let a_has_goal_complete = run_a_events
-        .iter()
-        .any(|e| matches!(e, AgentEvent::GoalComplete { .. }));
-    let b_has_goal_complete = run_b_events
-        .iter()
-        .any(|e| matches!(e, AgentEvent::GoalComplete { .. }));
-    assert!(
-        a_has_goal_complete,
-        "Run A should have emitted GoalComplete"
-    );
-    assert!(
-        b_has_goal_complete,
-        "Run B should have emitted GoalComplete"
-    );
+    let run_b_events = drain_events(&mut event_rx_b);
 
-    // Run B's GoalComplete must carry B's summary, never A's.
+    // B's GoalComplete must carry B's summary. This assertion also
+    // implicitly verifies A's completion reached A's channel and not B's.
     let b_summary = run_b_events.iter().find_map(|e| match e {
         AgentEvent::GoalComplete { summary } => Some(summary.clone()),
         _ => None,
     });
     assert_eq!(b_summary.as_deref(), Some("run B done"));
+    assert!(
+        run_a_events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::GoalComplete { .. })),
+        "Run A should have emitted GoalComplete on its own channel"
+    );
 }
 
 // ---------------------------------------------------------------------------
 // Scenario 3: Cached launch_app replay runs approval and post-tool hooks
-//
-// When a previous run cached a `launch_app` decision, replay must:
-//   - Re-request approval (state-changing tool).
-//   - Run the `maybe_cdp_connect` post-tool hook (probe_app, etc.).
-// Asserting the approval request arrives and the probe_app call fires
-// proves both behaviors wire through the cache-replay path.
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
 async fn cached_launch_app_replay_requests_approval_and_runs_post_tool_hook() {
-    // Seed the cache with a `launch_app` decision for a known page.
     let mut cache = AgentCache::default();
     let elements = vec![clickweave_core::cdp::CdpFindElementMatch {
         uid: "1_0".to_string(),
@@ -264,12 +252,9 @@ async fn cached_launch_app_replay_requests_approval_and_runs_post_tool_hook() {
         serde_json::json!({"app_name": "Calculator"}),
     );
 
-    // LLM only needs to handle the `done` step after replay.
     let agent_llm = MockAgent::new(vec![MockAgent::done_response("Launched via cache")]);
 
-    // MCP: advertises launch_app, probe_app, and cdp_connect so the
-    // post-tool hook has all its entry points. probe_app returns a
-    // "NativeApp" probe result so auto_connect_cdp short-circuits
+    // probe_app returns "NativeApp" so auto_connect_cdp short-circuits
     // before hitting the slow quit/relaunch path.
     let tools = vec![
         serde_json::json!({
@@ -310,23 +295,10 @@ async fn cached_launch_app_replay_requests_approval_and_runs_post_tool_hook() {
         }),
     ];
 
-    // Results: (1) first observation, (2) cached launch_app result,
-    // (3) probe_app returns NativeApp, (4) second observation,
-    // (5) fallbacks for any extra queries.
     let results = vec![
         cdp_button_page("https://example.com"),
-        ToolCallResult {
-            content: vec![ToolContent::Text {
-                text: "Launched".to_string(),
-            }],
-            is_error: None,
-        },
-        ToolCallResult {
-            content: vec![ToolContent::Text {
-                text: "NativeApp".to_string(),
-            }],
-            is_error: None,
-        },
+        text_result("Launched"),
+        text_result("NativeApp"),
         cdp_button_page("https://example.com/next"),
     ];
     let mcp = MockMcp::new(results, tools);
@@ -338,19 +310,9 @@ async fn cached_launch_app_replay_requests_approval_and_runs_post_tool_hook() {
         ..Default::default()
     };
 
-    // Approval harness — record whether an approval request was seen and
-    // auto-approve so the run progresses.
     let (event_tx, mut event_rx) = mpsc::channel::<AgentEvent>(64);
-    let (approval_tx, mut approval_rx) =
-        mpsc::channel::<(ApprovalRequest, oneshot::Sender<bool>)>(1);
-    let seen_approvals: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
-    let seen_clone = seen_approvals.clone();
-    tokio::spawn(async move {
-        while let Some((req, resp_tx)) = approval_rx.recv().await {
-            seen_clone.lock().unwrap().push(req.tool_name.clone());
-            let _ = resp_tx.send(true);
-        }
-    });
+    let (approval_tx, approval_rx) = approval_channel();
+    let (approver, seen_approvals) = spawn_recording_approver(approval_rx);
 
     let mut runner = AgentRunner::with_cache(&agent_llm, config, cache)
         .with_events(event_tx)
@@ -368,9 +330,8 @@ async fn cached_launch_app_replay_requests_approval_and_runs_post_tool_hook() {
         )
         .await
         .unwrap();
+    approver.abort();
 
-    // The replayed launch_app step must have passed through the approval
-    // gate — the harness observed a `launch_app` approval request.
     let approvals = seen_approvals.lock().unwrap();
     assert!(
         approvals.iter().any(|name| name == "launch_app"),
@@ -378,16 +339,13 @@ async fn cached_launch_app_replay_requests_approval_and_runs_post_tool_hook() {
         *approvals,
     );
 
-    // The post-tool hook must have fired — a SubAction event for probe_app
-    // is emitted from `auto_connect_cdp` before any Electron/CDP branching.
-    let mut saw_probe_sub_action = false;
-    while let Ok(ev) = event_rx.try_recv() {
-        if let AgentEvent::SubAction { tool_name, .. } = &ev
-            && tool_name == "probe_app"
-        {
-            saw_probe_sub_action = true;
-        }
-    }
+    let events = drain_events(&mut event_rx);
+    let saw_probe_sub_action = events.iter().any(|ev| {
+        matches!(
+            ev,
+            AgentEvent::SubAction { tool_name, .. } if tool_name == "probe_app"
+        )
+    });
     assert!(
         saw_probe_sub_action,
         "Cached launch_app replay must run the post-tool hook (probe_app SubAction)"
@@ -398,17 +356,13 @@ async fn cached_launch_app_replay_requests_approval_and_runs_post_tool_hook() {
 
 // ---------------------------------------------------------------------------
 // Scenario 4: Native / no-CDP path does not read or write the cache
-//
-// When `cdp_find_elements` returns no matches (native paths without CDP),
-// the cache lookup and cache store are both skipped — otherwise every
-// native step would collide on a degenerate empty-elements key.
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
 async fn empty_elements_skips_cache_read_and_write() {
     // Pre-seed the cache with an entry keyed on *empty* elements. If the
     // engine ever looked up using empty elements, this entry would hit
-    // and trigger a replay. The test proves it does not.
+    // and trigger a replay.
     let mut cache = AgentCache::default();
     cache.store(
         "click somewhere",
@@ -417,9 +371,6 @@ async fn empty_elements_skips_cache_read_and_write() {
         serde_json::json!({"x": 99, "y": 99}),
     );
 
-    // LLM proposes a click, then declares done. The pre-seeded cache
-    // must NOT be replayed (if it were, the LLM would only be invoked
-    // once — for the done step).
     let capturing: Arc<Mutex<Vec<Vec<Message>>>> = Arc::new(Mutex::new(Vec::new()));
     let llm = CapturingMockAgent::new(
         vec![
@@ -441,16 +392,7 @@ async fn empty_elements_skips_cache_read_and_write() {
             }
         }
     })];
-    let results = vec![
-        cdp_empty_page(), // step 0 observation (empty → no cache lookup)
-        ToolCallResult {
-            content: vec![ToolContent::Text {
-                text: "clicked".to_string(),
-            }],
-            is_error: None,
-        },
-        cdp_empty_page(), // step 1 observation (still empty)
-    ];
+    let results = vec![cdp_empty_page(), text_result("clicked"), cdp_empty_page()];
     let mcp = MockMcp::new(results, tools);
 
     let config = AgentConfig {
@@ -461,13 +403,8 @@ async fn empty_elements_skips_cache_read_and_write() {
     };
 
     let (event_tx, _event_rx) = mpsc::channel::<AgentEvent>(64);
-    let (approval_tx, mut approval_rx) =
-        mpsc::channel::<(ApprovalRequest, oneshot::Sender<bool>)>(1);
-    tokio::spawn(async move {
-        while let Some((_req, resp_tx)) = approval_rx.recv().await {
-            let _ = resp_tx.send(true);
-        }
-    });
+    let (approval_tx, approval_rx) = approval_channel();
+    let approver = spawn_auto_approver(approval_rx);
 
     let mut runner = AgentRunner::with_cache(&llm, config, cache)
         .with_events(event_tx)
@@ -484,11 +421,10 @@ async fn empty_elements_skips_cache_read_and_write() {
         )
         .await
         .unwrap();
+    approver.abort();
 
-    // The LLM was called twice — once for the click choice and once for
-    // the done call. If cache replay had fired (bug), the first step
-    // would be a cache-replayed click instead, and the LLM would be
-    // called for a NEW click in a later step (bug path).
+    // If cache replay had fired, the LLM would be called once (done only);
+    // with replay skipped, the LLM is called for both click and done.
     let calls = capturing.lock().unwrap();
     assert_eq!(
         calls.len(),
@@ -496,10 +432,8 @@ async fn empty_elements_skips_cache_read_and_write() {
         "LLM should be called twice (click + done) — empty elements must skip cache lookup"
     );
 
-    // Read-side guard: the first step's tool_call_id must be from the
-    // LLM response ("call_native_0"), not from the cache ("cache-0").
-    // If the cache read fired against empty elements, the pre-seeded
-    // entry would have replayed with a synthetic "cache-0" id.
+    // Read-side guard: the first step's tool_call_id comes from the LLM,
+    // not a synthetic "cache-0" id that would indicate a replay.
     match &state.steps[0].command {
         AgentCommand::ToolCall { tool_call_id, .. } => {
             assert_eq!(
@@ -511,10 +445,8 @@ async fn empty_elements_skips_cache_read_and_write() {
         other => panic!("Expected first step to be a ToolCall, got {:?}", other),
     }
 
-    // Write-side guard: the pre-seeded entry's hit_count must not have
-    // incremented. `store()` bumps hit_count, so if the click's empty
-    // observation triggered a cache write on success, the seed would
-    // have been overwritten with hit_count=2.
+    // Write-side guard: `store()` bumps hit_count. If the click had
+    // written into the cache on success, the seed's hit_count would be 2.
     drop(state);
     let final_cache = runner.into_cache();
     let seeded = final_cache
@@ -528,33 +460,20 @@ async fn empty_elements_skips_cache_read_and_write() {
 
 // ---------------------------------------------------------------------------
 // Scenario 5: Workflow-mapping miss emits Warning, not Error; run continues
-//
-// When the LLM calls a tool whose name is not mappable to a `NodeType`
-// and is not advertised via `known_tools`, the engine emits an
-// `AgentEvent::Warning` and the run proceeds — it must NOT terminate
-// with an error.
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
 async fn workflow_mapping_miss_emits_warning_and_run_continues() {
-    // LLM picks a tool name that is NOT in `known_tools`. The LLM can
-    // call any name via the tool_calls list, so we simulate a model that
-    // hallucinates a tool that the MCP doesn't advertise.
     let agent_llm = MockAgent::new(vec![
         MockAgent::tool_call_response("weird_tool", r#"{"foo": "bar"}"#, "call_weird"),
         MockAgent::done_response("Completed after mapping miss"),
     ]);
 
-    // MCP: no tools advertised — anything the LLM calls will map to an
-    // unknown-tool error during workflow-node construction.
+    // No tools advertised — any LLM tool name is unknown at workflow-node
+    // construction time.
     let results = vec![
         cdp_button_page("https://example.com"),
-        ToolCallResult {
-            content: vec![ToolContent::Text {
-                text: "executed".to_string(),
-            }],
-            is_error: None,
-        },
+        text_result("executed"),
         cdp_button_page("https://example.com/next"),
     ];
     let mcp = MockMcp::new(results, Vec::<Value>::new());
@@ -567,13 +486,8 @@ async fn workflow_mapping_miss_emits_warning_and_run_continues() {
     };
 
     let (event_tx, mut event_rx) = mpsc::channel::<AgentEvent>(64);
-    let (approval_tx, mut approval_rx) =
-        mpsc::channel::<(ApprovalRequest, oneshot::Sender<bool>)>(1);
-    tokio::spawn(async move {
-        while let Some((_req, resp_tx)) = approval_rx.recv().await {
-            let _ = resp_tx.send(true);
-        }
-    });
+    let (approval_tx, approval_rx) = approval_channel();
+    let approver = spawn_auto_approver(approval_rx);
 
     let mut runner = AgentRunner::new(&agent_llm, config)
         .with_events(event_tx)
@@ -590,27 +504,25 @@ async fn workflow_mapping_miss_emits_warning_and_run_continues() {
         )
         .await
         .unwrap();
+    approver.abort();
 
-    // Run completed — the mapping miss did NOT abort the loop.
     assert!(
         state.completed,
         "Mapping miss must not abort the loop, state={:?}",
         state.terminal_reason,
     );
 
-    // A Warning event was emitted; no terminal Error was emitted.
-    let mut saw_warning = false;
-    let mut saw_error = false;
-    while let Ok(ev) = event_rx.try_recv() {
-        match ev {
-            AgentEvent::Warning { .. } => saw_warning = true,
-            AgentEvent::Error { .. } => saw_error = true,
-            _ => {}
-        }
-    }
-    assert!(saw_warning, "Mapping miss must emit AgentEvent::Warning");
+    let events = drain_events(&mut event_rx);
     assert!(
-        !saw_error,
+        events
+            .iter()
+            .any(|ev| matches!(ev, AgentEvent::Warning { .. })),
+        "Mapping miss must emit AgentEvent::Warning"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|ev| matches!(ev, AgentEvent::Error { .. })),
         "Mapping miss must not emit AgentEvent::Error (the run continues)"
     );
 }

--- a/crates/clickweave-engine/src/agent/tests/coordination.rs
+++ b/crates/clickweave-engine/src/agent/tests/coordination.rs
@@ -1,0 +1,616 @@
+//! Cross-task coordination integration tests.
+//!
+//! These exercise the `AgentChannels` contract end-to-end — a harness task
+//! plays the role the Tauri forwarders play in production, and the
+//! assertions verify the engine responds to realistic cross-task event
+//! sequences. See `issue-101-agent-integration-tests` for the scenarios.
+
+use super::{CapturingMockAgent, MockAgent, MockMcp};
+use crate::agent::loop_runner::AgentRunner;
+use crate::agent::types::*;
+use crate::executor::Mcp;
+use clickweave_llm::Message;
+use clickweave_mcp::{ToolCallResult, ToolContent};
+use serde_json::Value;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::sync::{mpsc, oneshot};
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/// Build a successful CDP find-elements response with a single Submit button.
+/// Used as the standard "approval-gated" observation fixture.
+fn cdp_button_page(url: &str) -> ToolCallResult {
+    ToolCallResult {
+        content: vec![ToolContent::Text {
+            text: serde_json::json!({
+                "page_url": url,
+                "source": "cdp",
+                "matches": [{
+                    "uid": "1_0",
+                    "role": "button",
+                    "label": "Submit",
+                    "tag": "button"
+                }]
+            })
+            .to_string(),
+        }],
+        is_error: None,
+    }
+}
+
+/// Plain-text CDP find-elements response with zero matches.
+/// Used for native / no-CDP paths where elements are empty.
+fn cdp_empty_page() -> ToolCallResult {
+    ToolCallResult {
+        content: vec![ToolContent::Text {
+            text: serde_json::json!({
+                "page_url": "",
+                "source": "cdp",
+                "matches": []
+            })
+            .to_string(),
+        }],
+        is_error: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1: Stop during approval wait
+//
+// The Tauri approval forwarder's `AgentHandle::force_stop()` must drive the
+// engine to a `Rejected` outcome, not `ApprovalUnavailable`. The harness
+// below simulates the exact drop_on_cancel-vs-send_false difference:
+// dropping the oneshot sender surfaces as `ApprovalUnavailable`, while
+// explicitly sending `false` surfaces as `Rejected` → `Replan`.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn stop_during_approval_wait_sends_rejection_not_channel_drop() {
+    // The LLM proposes a click that needs approval, then after the replan
+    // declares the goal done (so the run can reach a terminal state).
+    let agent_llm = MockAgent::new(vec![
+        MockAgent::tool_call_response("click", r#"{"x": 10, "y": 20}"#, "call_0"),
+        MockAgent::done_response("Found another way after cancel"),
+    ]);
+    let mcp = MockMcp::with_click_tool();
+
+    let config = AgentConfig {
+        max_steps: 5,
+        build_workflow: false,
+        use_cache: false,
+        ..Default::default()
+    };
+
+    let (event_tx, _event_rx) = mpsc::channel::<AgentEvent>(64);
+    let (approval_tx, mut approval_rx) =
+        mpsc::channel::<(ApprovalRequest, oneshot::Sender<bool>)>(1);
+
+    // Harness: mimic `AgentHandle::force_stop()` — receive the approval
+    // request, then instead of dropping the oneshot, send `false` on it
+    // (the fix) so the engine observes an explicit rejection and replans
+    // rather than tearing down with `ApprovalUnavailable`.
+    tokio::spawn(async move {
+        if let Some((_req, resp_tx)) = approval_rx.recv().await {
+            // Simulate a brief approval-wait window.
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            let _ = resp_tx.send(false);
+        }
+    });
+
+    let mut runner = AgentRunner::new(&agent_llm, config)
+        .with_events(event_tx)
+        .with_approval(approval_tx);
+    let workflow = clickweave_core::Workflow::new("Stop-during-approval");
+    let mcp_tools = mcp.tools_as_openai();
+
+    let state = runner
+        .run("Click it".to_string(), workflow, &mcp, None, mcp_tools)
+        .await
+        .unwrap();
+
+    // Explicit rejection must surface as Replan (the terminal state of the
+    // cancelled step), never as ApprovalUnavailable.
+    assert!(
+        matches!(state.steps[0].outcome, StepOutcome::Replan(_)),
+        "Expected Replan after force_stop rejection, got {:?}",
+        state.steps[0].outcome,
+    );
+    assert!(
+        !matches!(
+            state.terminal_reason,
+            Some(TerminalReason::ApprovalUnavailable)
+        ),
+        "force_stop must not surface as ApprovalUnavailable, got {:?}",
+        state.terminal_reason,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2: Buffered events drained between runs do not leak
+//
+// The event forwarder in Tauri drains remaining events on cancel. The
+// engine-level contract is: whatever the forwarder sees on the event
+// channel is tagged with the run_id it began forwarding for. This test
+// demonstrates that two back-to-back runs each have their own event
+// streams — channel A's events cannot appear on channel B.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn buffered_events_do_not_leak_between_runs() {
+    // Run A — produce several events, then let them sit in the buffer.
+    let llm_a = MockAgent::new(vec![
+        MockAgent::tool_call_response("click", r#"{"x": 1, "y": 2}"#, "call_a0"),
+        MockAgent::done_response("run A done"),
+    ]);
+    let mcp_a = MockMcp::with_click_tool();
+
+    let (event_tx_a, mut event_rx_a) = mpsc::channel::<AgentEvent>(64);
+    // Auto-approve so the run progresses without external coordination.
+    let (approval_tx_a, mut approval_rx_a) =
+        mpsc::channel::<(ApprovalRequest, oneshot::Sender<bool>)>(1);
+    tokio::spawn(async move {
+        while let Some((_req, resp_tx)) = approval_rx_a.recv().await {
+            let _ = resp_tx.send(true);
+        }
+    });
+
+    let mut runner_a = AgentRunner::new(&llm_a, AgentConfig::default())
+        .with_events(event_tx_a)
+        .with_approval(approval_tx_a);
+    let _ = runner_a
+        .run(
+            "goal A".to_string(),
+            clickweave_core::Workflow::new("A"),
+            &mcp_a,
+            None,
+            mcp_a.tools_as_openai(),
+        )
+        .await
+        .unwrap();
+
+    // Drain run A's events — all events collected here are tagged with
+    // run A's lifecycle (the channel is exclusively A's).
+    let mut run_a_events = Vec::new();
+    while let Ok(ev) = event_rx_a.try_recv() {
+        run_a_events.push(ev);
+    }
+    assert!(!run_a_events.is_empty(), "Run A must have produced events");
+
+    // Run B — fresh channels. Run A's channel is dropped; B's sender
+    // cannot carry A's history.
+    let llm_b = MockAgent::new(vec![MockAgent::done_response("run B done")]);
+    let mcp_b = MockMcp::with_click_tool();
+
+    let (event_tx_b, mut event_rx_b) = mpsc::channel::<AgentEvent>(64);
+    let (approval_tx_b, _approval_rx_b) =
+        mpsc::channel::<(ApprovalRequest, oneshot::Sender<bool>)>(1);
+    let mut runner_b = AgentRunner::new(&llm_b, AgentConfig::default())
+        .with_events(event_tx_b)
+        .with_approval(approval_tx_b);
+    let _ = runner_b
+        .run(
+            "goal B".to_string(),
+            clickweave_core::Workflow::new("B"),
+            &mcp_b,
+            None,
+            mcp_b.tools_as_openai(),
+        )
+        .await
+        .unwrap();
+
+    // Collect run B's events. The count of B's events must match what B
+    // produced, with zero contamination from A (the channels are isolated
+    // so this is trivially true at the engine layer — we document the
+    // contract that Tauri's forwarder relies on).
+    let mut run_b_events = Vec::new();
+    while let Ok(ev) = event_rx_b.try_recv() {
+        run_b_events.push(ev);
+    }
+    // Both runs should have emitted GoalComplete. A's GoalComplete must
+    // have arrived on A's channel only.
+    let a_has_goal_complete = run_a_events
+        .iter()
+        .any(|e| matches!(e, AgentEvent::GoalComplete { .. }));
+    let b_has_goal_complete = run_b_events
+        .iter()
+        .any(|e| matches!(e, AgentEvent::GoalComplete { .. }));
+    assert!(
+        a_has_goal_complete,
+        "Run A should have emitted GoalComplete"
+    );
+    assert!(
+        b_has_goal_complete,
+        "Run B should have emitted GoalComplete"
+    );
+
+    // Run B's GoalComplete must carry B's summary, never A's.
+    let b_summary = run_b_events.iter().find_map(|e| match e {
+        AgentEvent::GoalComplete { summary } => Some(summary.clone()),
+        _ => None,
+    });
+    assert_eq!(b_summary.as_deref(), Some("run B done"));
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 3: Cached launch_app replay runs approval and post-tool hooks
+//
+// When a previous run cached a `launch_app` decision, replay must:
+//   - Re-request approval (state-changing tool).
+//   - Run the `maybe_cdp_connect` post-tool hook (probe_app, etc.).
+// Asserting the approval request arrives and the probe_app call fires
+// proves both behaviors wire through the cache-replay path.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn cached_launch_app_replay_requests_approval_and_runs_post_tool_hook() {
+    // Seed the cache with a `launch_app` decision for a known page.
+    let mut cache = AgentCache::default();
+    let elements = vec![clickweave_core::cdp::CdpFindElementMatch {
+        uid: "1_0".to_string(),
+        role: "button".to_string(),
+        label: "Submit".to_string(),
+        tag: "button".to_string(),
+        disabled: false,
+        parent_role: None,
+        parent_name: None,
+    }];
+    cache.store(
+        "launch Calculator",
+        &elements,
+        "launch_app".to_string(),
+        serde_json::json!({"app_name": "Calculator"}),
+    );
+
+    // LLM only needs to handle the `done` step after replay.
+    let agent_llm = MockAgent::new(vec![MockAgent::done_response("Launched via cache")]);
+
+    // MCP: advertises launch_app, probe_app, and cdp_connect so the
+    // post-tool hook has all its entry points. probe_app returns a
+    // "NativeApp" probe result so auto_connect_cdp short-circuits
+    // before hitting the slow quit/relaunch path.
+    let tools = vec![
+        serde_json::json!({
+            "type": "function",
+            "function": {
+                "name": "launch_app",
+                "description": "Launch an app",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"app_name": {"type": "string"}},
+                    "required": ["app_name"]
+                }
+            }
+        }),
+        serde_json::json!({
+            "type": "function",
+            "function": {
+                "name": "probe_app",
+                "description": "Probe an app",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"app_name": {"type": "string"}},
+                    "required": ["app_name"]
+                }
+            }
+        }),
+        serde_json::json!({
+            "type": "function",
+            "function": {
+                "name": "cdp_connect",
+                "description": "Connect to CDP",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"port": {"type": "number"}},
+                    "required": ["port"]
+                }
+            }
+        }),
+    ];
+
+    // Results: (1) first observation, (2) cached launch_app result,
+    // (3) probe_app returns NativeApp, (4) second observation,
+    // (5) fallbacks for any extra queries.
+    let results = vec![
+        cdp_button_page("https://example.com"),
+        ToolCallResult {
+            content: vec![ToolContent::Text {
+                text: "Launched".to_string(),
+            }],
+            is_error: None,
+        },
+        ToolCallResult {
+            content: vec![ToolContent::Text {
+                text: "NativeApp".to_string(),
+            }],
+            is_error: None,
+        },
+        cdp_button_page("https://example.com/next"),
+    ];
+    let mcp = MockMcp::new(results, tools);
+
+    let config = AgentConfig {
+        max_steps: 5,
+        build_workflow: false,
+        use_cache: true,
+        ..Default::default()
+    };
+
+    // Approval harness — record whether an approval request was seen and
+    // auto-approve so the run progresses.
+    let (event_tx, mut event_rx) = mpsc::channel::<AgentEvent>(64);
+    let (approval_tx, mut approval_rx) =
+        mpsc::channel::<(ApprovalRequest, oneshot::Sender<bool>)>(1);
+    let seen_approvals: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let seen_clone = seen_approvals.clone();
+    tokio::spawn(async move {
+        while let Some((req, resp_tx)) = approval_rx.recv().await {
+            seen_clone.lock().unwrap().push(req.tool_name.clone());
+            let _ = resp_tx.send(true);
+        }
+    });
+
+    let mut runner = AgentRunner::with_cache(&agent_llm, config, cache)
+        .with_events(event_tx)
+        .with_approval(approval_tx);
+    let workflow = clickweave_core::Workflow::new("Cache-replay launch");
+    let mcp_tools = mcp.tools_as_openai();
+
+    let state = runner
+        .run(
+            "launch Calculator".to_string(),
+            workflow,
+            &mcp,
+            None,
+            mcp_tools,
+        )
+        .await
+        .unwrap();
+
+    // The replayed launch_app step must have passed through the approval
+    // gate — the harness observed a `launch_app` approval request.
+    let approvals = seen_approvals.lock().unwrap();
+    assert!(
+        approvals.iter().any(|name| name == "launch_app"),
+        "Cached launch_app replay must re-request approval, saw {:?}",
+        *approvals,
+    );
+
+    // The post-tool hook must have fired — a SubAction event for probe_app
+    // is emitted from `auto_connect_cdp` before any Electron/CDP branching.
+    let mut saw_probe_sub_action = false;
+    while let Ok(ev) = event_rx.try_recv() {
+        if let AgentEvent::SubAction { tool_name, .. } = &ev
+            && tool_name == "probe_app"
+        {
+            saw_probe_sub_action = true;
+        }
+    }
+    assert!(
+        saw_probe_sub_action,
+        "Cached launch_app replay must run the post-tool hook (probe_app SubAction)"
+    );
+
+    assert!(state.completed);
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 4: Native / no-CDP path does not read or write the cache
+//
+// When `cdp_find_elements` returns no matches (native paths without CDP),
+// the cache lookup and cache store are both skipped — otherwise every
+// native step would collide on a degenerate empty-elements key.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn empty_elements_skips_cache_read_and_write() {
+    // Pre-seed the cache with an entry keyed on *empty* elements. If the
+    // engine ever looked up using empty elements, this entry would hit
+    // and trigger a replay. The test proves it does not.
+    let mut cache = AgentCache::default();
+    cache.store(
+        "click somewhere",
+        &[],
+        "click".to_string(),
+        serde_json::json!({"x": 99, "y": 99}),
+    );
+
+    // LLM proposes a click, then declares done. The pre-seeded cache
+    // must NOT be replayed (if it were, the LLM would only be invoked
+    // once — for the done step).
+    let capturing: Arc<Mutex<Vec<Vec<Message>>>> = Arc::new(Mutex::new(Vec::new()));
+    let llm = CapturingMockAgent::new(
+        vec![
+            MockAgent::tool_call_response("click", r#"{"x": 5, "y": 5}"#, "call_native_0"),
+            MockAgent::done_response("Done without cache"),
+        ],
+        capturing.clone(),
+    );
+
+    let tools = vec![serde_json::json!({
+        "type": "function",
+        "function": {
+            "name": "click",
+            "description": "Click",
+            "parameters": {
+                "type": "object",
+                "properties": {"x": {"type": "number"}, "y": {"type": "number"}},
+                "required": ["x", "y"]
+            }
+        }
+    })];
+    let results = vec![
+        cdp_empty_page(), // step 0 observation (empty → no cache lookup)
+        ToolCallResult {
+            content: vec![ToolContent::Text {
+                text: "clicked".to_string(),
+            }],
+            is_error: None,
+        },
+        cdp_empty_page(), // step 1 observation (still empty)
+    ];
+    let mcp = MockMcp::new(results, tools);
+
+    let config = AgentConfig {
+        max_steps: 5,
+        build_workflow: false,
+        use_cache: true,
+        ..Default::default()
+    };
+
+    let (event_tx, _event_rx) = mpsc::channel::<AgentEvent>(64);
+    let (approval_tx, mut approval_rx) =
+        mpsc::channel::<(ApprovalRequest, oneshot::Sender<bool>)>(1);
+    tokio::spawn(async move {
+        while let Some((_req, resp_tx)) = approval_rx.recv().await {
+            let _ = resp_tx.send(true);
+        }
+    });
+
+    let mut runner = AgentRunner::with_cache(&llm, config, cache)
+        .with_events(event_tx)
+        .with_approval(approval_tx);
+    let workflow = clickweave_core::Workflow::new("Native-no-cache");
+    let mcp_tools = mcp.tools_as_openai();
+    let state = runner
+        .run(
+            "click somewhere".to_string(),
+            workflow,
+            &mcp,
+            None,
+            mcp_tools,
+        )
+        .await
+        .unwrap();
+
+    // The LLM was called twice — once for the click choice and once for
+    // the done call. If cache replay had fired (bug), the first step
+    // would be a cache-replayed click instead, and the LLM would be
+    // called for a NEW click in a later step (bug path).
+    let calls = capturing.lock().unwrap();
+    assert_eq!(
+        calls.len(),
+        2,
+        "LLM should be called twice (click + done) — empty elements must skip cache lookup"
+    );
+
+    // Read-side guard: the first step's tool_call_id must be from the
+    // LLM response ("call_native_0"), not from the cache ("cache-0").
+    // If the cache read fired against empty elements, the pre-seeded
+    // entry would have replayed with a synthetic "cache-0" id.
+    match &state.steps[0].command {
+        AgentCommand::ToolCall { tool_call_id, .. } => {
+            assert_eq!(
+                tool_call_id, "call_native_0",
+                "Empty-elements observation must not trigger cache replay — \
+                 first step should come from the LLM, not the cache"
+            );
+        }
+        other => panic!("Expected first step to be a ToolCall, got {:?}", other),
+    }
+
+    // Write-side guard: the pre-seeded entry's hit_count must not have
+    // incremented. `store()` bumps hit_count, so if the click's empty
+    // observation triggered a cache write on success, the seed would
+    // have been overwritten with hit_count=2.
+    drop(state);
+    let final_cache = runner.into_cache();
+    let seeded = final_cache
+        .lookup("click somewhere", &[])
+        .expect("pre-seeded entry should still exist");
+    assert_eq!(
+        seeded.hit_count, 1,
+        "empty-elements click must not touch the cache — hit_count should stay at 1"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 5: Workflow-mapping miss emits Warning, not Error; run continues
+//
+// When the LLM calls a tool whose name is not mappable to a `NodeType`
+// and is not advertised via `known_tools`, the engine emits an
+// `AgentEvent::Warning` and the run proceeds — it must NOT terminate
+// with an error.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn workflow_mapping_miss_emits_warning_and_run_continues() {
+    // LLM picks a tool name that is NOT in `known_tools`. The LLM can
+    // call any name via the tool_calls list, so we simulate a model that
+    // hallucinates a tool that the MCP doesn't advertise.
+    let agent_llm = MockAgent::new(vec![
+        MockAgent::tool_call_response("weird_tool", r#"{"foo": "bar"}"#, "call_weird"),
+        MockAgent::done_response("Completed after mapping miss"),
+    ]);
+
+    // MCP: no tools advertised — anything the LLM calls will map to an
+    // unknown-tool error during workflow-node construction.
+    let results = vec![
+        cdp_button_page("https://example.com"),
+        ToolCallResult {
+            content: vec![ToolContent::Text {
+                text: "executed".to_string(),
+            }],
+            is_error: None,
+        },
+        cdp_button_page("https://example.com/next"),
+    ];
+    let mcp = MockMcp::new(results, Vec::<Value>::new());
+
+    let config = AgentConfig {
+        max_steps: 5,
+        build_workflow: true,
+        use_cache: false,
+        ..Default::default()
+    };
+
+    let (event_tx, mut event_rx) = mpsc::channel::<AgentEvent>(64);
+    let (approval_tx, mut approval_rx) =
+        mpsc::channel::<(ApprovalRequest, oneshot::Sender<bool>)>(1);
+    tokio::spawn(async move {
+        while let Some((_req, resp_tx)) = approval_rx.recv().await {
+            let _ = resp_tx.send(true);
+        }
+    });
+
+    let mut runner = AgentRunner::new(&agent_llm, config)
+        .with_events(event_tx)
+        .with_approval(approval_tx);
+    let workflow = clickweave_core::Workflow::new("Mapping-miss");
+    let mcp_tools = mcp.tools_as_openai();
+    let state = runner
+        .run(
+            "trigger mapping miss".to_string(),
+            workflow,
+            &mcp,
+            None,
+            mcp_tools,
+        )
+        .await
+        .unwrap();
+
+    // Run completed — the mapping miss did NOT abort the loop.
+    assert!(
+        state.completed,
+        "Mapping miss must not abort the loop, state={:?}",
+        state.terminal_reason,
+    );
+
+    // A Warning event was emitted; no terminal Error was emitted.
+    let mut saw_warning = false;
+    let mut saw_error = false;
+    while let Ok(ev) = event_rx.try_recv() {
+        match ev {
+            AgentEvent::Warning { .. } => saw_warning = true,
+            AgentEvent::Error { .. } => saw_error = true,
+            _ => {}
+        }
+    }
+    assert!(saw_warning, "Mapping miss must emit AgentEvent::Warning");
+    assert!(
+        !saw_error,
+        "Mapping miss must not emit AgentEvent::Error (the run continues)"
+    );
+}

--- a/crates/clickweave-engine/src/agent/tests/mod.rs
+++ b/crates/clickweave-engine/src/agent/tests/mod.rs
@@ -1272,3 +1272,15 @@ async fn retained_history_stays_bounded_across_snapshot_heavy_steps() {
         body.len()
     );
 }
+
+// ---------------------------------------------------------------------------
+// Cross-task / cross-process coordination tests
+//
+// These exercise the full `AgentChannels` contract end-to-end: a harness
+// task plays the role the Tauri forwarders play in production, and the
+// assertions verify the engine responds to realistic sequences of events
+// (stop-during-approval, cache replay through the approval gate, empty-
+// elements native paths, tool-mapping misses, cross-run event draining).
+// ---------------------------------------------------------------------------
+
+mod coordination;

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -571,7 +571,7 @@ mod tests {
     /// Tauri command can return a validation error instead of silently
     /// succeeding.
     #[test]
-    fn force_stop_reports_no_run_active() {
+    fn force_stop_returns_false_when_no_run_active() {
         let mut handle = AgentHandle::default();
         let had_task = handle.force_stop();
         assert!(

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -502,3 +502,81 @@ pub async fn approve_agent_action(
         CommandError::validation("Approval channel closed — agent task may have ended")
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression: `AgentHandle::force_stop` must NOT drop the pending
+    /// approval sender silently. Dropping surfaces to the engine as
+    /// `Err(channel closed)` → `TerminalReason::ApprovalUnavailable`,
+    /// which the Tauri layer then emits as `agent://stopped { reason:
+    /// approval_unavailable }`. The fix sends `Ok(false)` explicitly so
+    /// the engine treats the stop as a rejection (`Replan`) and the
+    /// outer select races on `cancel_token.cancel()` to emit
+    /// `agent://stopped { reason: cancelled }`.
+    #[test]
+    fn force_stop_sends_rejection_through_pending_approval() {
+        let (tx, rx) = tokio::sync::oneshot::channel::<bool>();
+        let mut handle = AgentHandle {
+            cancel_token: Some(CancellationToken::new()),
+            pending_approval_tx: Some(tx),
+            ..Default::default()
+        };
+
+        let had_task = handle.force_stop();
+
+        assert!(
+            had_task,
+            "force_stop should report true when cancel_token is installed"
+        );
+        // The receiver must see `Ok(false)` — not `Err` from a dropped sender.
+        assert_eq!(
+            rx.blocking_recv(),
+            Ok(false),
+            "force_stop must send explicit rejection, not drop the oneshot"
+        );
+    }
+
+    /// `force_stop` must also cancel the CancellationToken so the outer
+    /// agent task observes the stop during the spawn window (before
+    /// `task_handle` is installed). The scenario: a user hits Stop while
+    /// MCP spawn is still in progress.
+    #[test]
+    fn force_stop_cancels_token_for_spawn_window_stop() {
+        let token = CancellationToken::new();
+        let mut handle = AgentHandle {
+            cancel_token: Some(token.clone()),
+            ..Default::default()
+        };
+        // Simulate the spawn window: no task_handle, no pending approval.
+        // `force_stop` must still succeed — the token alone is sufficient
+        // evidence that a run is in flight.
+
+        let had_task = handle.force_stop();
+
+        assert!(
+            had_task,
+            "force_stop must return true when a cancel_token is present \
+             even without a task_handle (the spawn window)"
+        );
+        assert!(
+            token.is_cancelled(),
+            "The CancellationToken must be cancelled so the spawning \
+             task sees the stop before it finishes MCP bring-up"
+        );
+    }
+
+    /// `force_stop` must return false when no run is active, so the
+    /// Tauri command can return a validation error instead of silently
+    /// succeeding.
+    #[test]
+    fn force_stop_reports_no_run_active() {
+        let mut handle = AgentHandle::default();
+        let had_task = handle.force_stop();
+        assert!(
+            !had_task,
+            "force_stop must return false when no run is active"
+        );
+    }
+}

--- a/ui/src/hooks/events/useAgentEvents.test.ts
+++ b/ui/src/hooks/events/useAgentEvents.test.ts
@@ -1,30 +1,16 @@
 import { describe, it, expect } from "vitest";
 import { isStaleRunId } from "./useAgentEvents";
 
-// Regression tests for the null-gap that used to allow events from a
-// previous agent run to leak into a subsequent run. The fix:
-// `agentRunId === null` is treated as stale, even before the new
-// `agent://started` event installs the next run_id.
-
 describe("isStaleRunId", () => {
-  it("drops events when no run is active (null-gap guard)", () => {
-    // Stop/restart leaves a window where agentRunId is null but events
-    // from the previous run can still arrive. All such events are stale.
+  it("treats a null active run as stale so events during stop/restart are dropped", () => {
     expect(isStaleRunId(null, "run-a")).toBe(true);
-    expect(isStaleRunId(null, "")).toBe(true);
   });
 
-  it("drops events from a previous run_id", () => {
-    // Run A was active; run B just started. An in-flight event from A
-    // must not update run B's state.
+  it("rejects events whose run_id does not match the active run", () => {
     expect(isStaleRunId("run-b", "run-a")).toBe(true);
   });
 
-  it("passes events matching the active run_id", () => {
+  it("accepts events whose run_id matches the active run", () => {
     expect(isStaleRunId("run-b", "run-b")).toBe(false);
-  });
-
-  it("rejects empty incoming run_id when active run is set", () => {
-    expect(isStaleRunId("run-a", "")).toBe(true);
   });
 });

--- a/ui/src/hooks/events/useAgentEvents.test.ts
+++ b/ui/src/hooks/events/useAgentEvents.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { isStaleRunId } from "./useAgentEvents";
+
+// Regression tests for the null-gap that used to allow events from a
+// previous agent run to leak into a subsequent run. The fix:
+// `agentRunId === null` is treated as stale, even before the new
+// `agent://started` event installs the next run_id.
+
+describe("isStaleRunId", () => {
+  it("drops events when no run is active (null-gap guard)", () => {
+    // Stop/restart leaves a window where agentRunId is null but events
+    // from the previous run can still arrive. All such events are stale.
+    expect(isStaleRunId(null, "run-a")).toBe(true);
+    expect(isStaleRunId(null, "")).toBe(true);
+  });
+
+  it("drops events from a previous run_id", () => {
+    // Run A was active; run B just started. An in-flight event from A
+    // must not update run B's state.
+    expect(isStaleRunId("run-b", "run-a")).toBe(true);
+  });
+
+  it("passes events matching the active run_id", () => {
+    expect(isStaleRunId("run-b", "run-b")).toBe(false);
+  });
+
+  it("rejects empty incoming run_id when active run is set", () => {
+    expect(isStaleRunId("run-a", "")).toBe(true);
+  });
+});

--- a/ui/src/hooks/events/useAgentEvents.ts
+++ b/ui/src/hooks/events/useAgentEvents.ts
@@ -9,6 +9,20 @@ interface RunScoped {
   run_id: string;
 }
 
+/**
+ * Reject events from a stale run or during the null gap before
+ * `agent://started` installs the active run ID.
+ *
+ * Exported as a pure helper so unit tests can verify the null-gap
+ * guard without spinning up a Tauri event listener.
+ */
+export function isStaleRunId(
+  activeRunId: string | null,
+  incomingRunId: string,
+): boolean {
+  return activeRunId === null || incomingRunId !== activeRunId;
+}
+
 interface AgentStartedPayload extends RunScoped {}
 
 interface AgentStepPayload extends RunScoped {
@@ -87,10 +101,8 @@ export function useAgentEvents() {
         });
 
     /** Reject events from a stale run or during the null gap before agent://started. */
-    const isStale = (runId: string): boolean => {
-      const activeRunId = useStore.getState().agentRunId;
-      return activeRunId === null || runId !== activeRunId;
-    };
+    const isStale = (runId: string): boolean =>
+      isStaleRunId(useStore.getState().agentRunId, runId);
 
     // ── Run lifecycle ──────────────────────────────────────────
 

--- a/ui/src/store/slices/agentSlice.test.ts
+++ b/ui/src/store/slices/agentSlice.test.ts
@@ -9,17 +9,12 @@ vi.mock("@tauri-apps/api/core", () => ({
 
 import { useStore } from "../useAppStore";
 
-describe("agentSlice.startAgent — already_running surfaces as error state", () => {
+describe("agentSlice.startAgent", () => {
   beforeEach(() => {
     invokeMock.mockReset();
     useStore.getState().resetAgent();
   });
 
-  // Regression: during the MCP spawn window a second `run_agent` call
-  // must be rejected at the Tauri layer with `AlreadyRunning`. The
-  // frontend must surface that rejection as an `error` status with
-  // a non-null error message — not silently set status back to `running`
-  // or swallow the rejection.
   it("surfaces AlreadyRunning rejections into agentStatus=error", async () => {
     invokeMock.mockRejectedValueOnce({
       kind: "AlreadyRunning",
@@ -34,9 +29,7 @@ describe("agentSlice.startAgent — already_running surfaces as error state", ()
     expect(state.agentError).not.toBe("");
   });
 
-  // Same guarantee when the error arrives as a plain string — the
-  // Tauri-specta layer serializes `CommandError` through Display.
-  it("surfaces AlreadyRunning string-serialized rejection into agentStatus=error", async () => {
+  it("surfaces string-serialized AlreadyRunning rejections into agentStatus=error", async () => {
     invokeMock.mockRejectedValueOnce("AlreadyRunning: Already running");
 
     await useStore.getState().startAgent("do something");
@@ -46,7 +39,7 @@ describe("agentSlice.startAgent — already_running surfaces as error state", ()
     expect(state.agentError).toMatch(/already running/i);
   });
 
-  it("stays in running state when invoke succeeds (no error path)", async () => {
+  it("stays in running state when invoke succeeds", async () => {
     invokeMock.mockResolvedValueOnce(undefined);
 
     await useStore.getState().startAgent("do something else");
@@ -56,19 +49,12 @@ describe("agentSlice.startAgent — already_running surfaces as error state", ()
     expect(state.agentError).toBeNull();
   });
 
-  it("clears previous agentRunId when starting a new run (null-gap arms)", async () => {
-    // Simulate a prior run: install a run_id.
+  it("clears the previous agentRunId before invoke so stale events are treated as stale", async () => {
     useStore.getState().setAgentRunId("run-prior");
-    expect(useStore.getState().agentRunId).toBe("run-prior");
-
-    invokeMock.mockImplementationOnce(async () => {
-      // At the moment invoke is in flight, the store must have already
-      // dropped the previous run_id so any in-flight events from
-      // "run-prior" are treated as stale by the null-gap guard.
-      expect(useStore.getState().agentRunId).toBeNull();
-      return undefined;
-    });
+    invokeMock.mockResolvedValueOnce(undefined);
 
     await useStore.getState().startAgent("fresh goal");
+
+    expect(useStore.getState().agentRunId).toBeNull();
   });
 });

--- a/ui/src/store/slices/agentSlice.test.ts
+++ b/ui/src/store/slices/agentSlice.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Tauri's `invoke` must be mocked before agentSlice is imported — the
+// slice captures the imported binding at module init time.
+const invokeMock = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+import { useStore } from "../useAppStore";
+
+describe("agentSlice.startAgent — already_running surfaces as error state", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    useStore.getState().resetAgent();
+  });
+
+  // Regression: during the MCP spawn window a second `run_agent` call
+  // must be rejected at the Tauri layer with `AlreadyRunning`. The
+  // frontend must surface that rejection as an `error` status with
+  // a non-null error message — not silently set status back to `running`
+  // or swallow the rejection.
+  it("surfaces AlreadyRunning rejections into agentStatus=error", async () => {
+    invokeMock.mockRejectedValueOnce({
+      kind: "AlreadyRunning",
+      message: "Already running",
+    });
+
+    await useStore.getState().startAgent("do something");
+
+    const state = useStore.getState();
+    expect(state.agentStatus).toBe("error");
+    expect(state.agentError).not.toBeNull();
+    expect(state.agentError).not.toBe("");
+  });
+
+  // Same guarantee when the error arrives as a plain string — the
+  // Tauri-specta layer serializes `CommandError` through Display.
+  it("surfaces AlreadyRunning string-serialized rejection into agentStatus=error", async () => {
+    invokeMock.mockRejectedValueOnce("AlreadyRunning: Already running");
+
+    await useStore.getState().startAgent("do something");
+
+    const state = useStore.getState();
+    expect(state.agentStatus).toBe("error");
+    expect(state.agentError).toMatch(/already running/i);
+  });
+
+  it("stays in running state when invoke succeeds (no error path)", async () => {
+    invokeMock.mockResolvedValueOnce(undefined);
+
+    await useStore.getState().startAgent("do something else");
+
+    const state = useStore.getState();
+    expect(state.agentStatus).toBe("running");
+    expect(state.agentError).toBeNull();
+  });
+
+  it("clears previous agentRunId when starting a new run (null-gap arms)", async () => {
+    // Simulate a prior run: install a run_id.
+    useStore.getState().setAgentRunId("run-prior");
+    expect(useStore.getState().agentRunId).toBe("run-prior");
+
+    invokeMock.mockImplementationOnce(async () => {
+      // At the moment invoke is in flight, the store must have already
+      // dropped the previous run_id so any in-flight events from
+      // "run-prior" are treated as stale by the null-gap guard.
+      expect(useStore.getState().agentRunId).toBeNull();
+      return undefined;
+    });
+
+    await useStore.getState().startAgent("fresh goal");
+  });
+});

--- a/ui/src/store/slices/agentSlice.test.ts
+++ b/ui/src/store/slices/agentSlice.test.ts
@@ -25,8 +25,7 @@ describe("agentSlice.startAgent", () => {
 
     const state = useStore.getState();
     expect(state.agentStatus).toBe("error");
-    expect(state.agentError).not.toBeNull();
-    expect(state.agentError).not.toBe("");
+    expect(state.agentError).toBe("Already running");
   });
 
   it("surfaces string-serialized AlreadyRunning rejections into agentStatus=error", async () => {

--- a/ui/src/store/slices/agentSlice.test.ts
+++ b/ui/src/store/slices/agentSlice.test.ts
@@ -57,3 +57,48 @@ describe("agentSlice.startAgent", () => {
     expect(useStore.getState().agentRunId).toBeNull();
   });
 });
+
+describe("agentSlice approval actions", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    useStore.getState().resetAgent();
+  });
+
+  it("formats structured Tauri errors from approveAction into the activity log", async () => {
+    useStore.getState().setPendingApproval({
+      stepIndex: 0,
+      toolName: "click",
+      arguments: {},
+      description: "Click the button",
+    });
+    invokeMock.mockRejectedValueOnce({
+      kind: "Validation",
+      message: "No pending approval request",
+    });
+
+    await useStore.getState().approveAction();
+
+    const lastLog = useStore.getState().logs.at(-1);
+    expect(lastLog).toContain("No pending approval request");
+    expect(lastLog).not.toContain("[object Object]");
+  });
+
+  it("formats structured Tauri errors from rejectAction into the activity log", async () => {
+    useStore.getState().setPendingApproval({
+      stepIndex: 0,
+      toolName: "click",
+      arguments: {},
+      description: "Click the button",
+    });
+    invokeMock.mockRejectedValueOnce({
+      kind: "Validation",
+      message: "Approval channel closed — agent task may have ended",
+    });
+
+    await useStore.getState().rejectAction();
+
+    const lastLog = useStore.getState().logs.at(-1);
+    expect(lastLog).toContain("Approval channel closed");
+    expect(lastLog).not.toContain("[object Object]");
+  });
+});

--- a/ui/src/store/slices/agentSlice.ts
+++ b/ui/src/store/slices/agentSlice.ts
@@ -21,6 +21,21 @@ export interface PendingApproval {
   description: string;
 }
 
+/**
+ * Tauri rejects with a structured `CommandError { kind, message }` for
+ * typed failures (e.g. `AlreadyRunning`), but tauri-specta can also
+ * surface plain strings when an error is serialized through `Display`.
+ * Prefer the structured `message`, fall back to string coercion.
+ */
+function formatAgentError(err: unknown): string {
+  if (err && typeof err === "object" && "message" in err) {
+    const m = (err as { message?: unknown }).message;
+    if (typeof m === "string" && m.length > 0) return m;
+  }
+  if (typeof err === "string") return err;
+  return String(err);
+}
+
 export interface AgentSlice {
   agentStatus: AgentStatus;
   agentGoal: string;
@@ -79,7 +94,7 @@ export const createAgentSlice: StateCreator<StoreState, [], [], AgentSlice> = (
         },
       });
     } catch (err) {
-      const msg = `${err}`;
+      const msg = formatAgentError(err);
       set({ agentStatus: "error", agentError: msg });
       pushLog(`Agent failed: ${msg}`);
     }

--- a/ui/src/store/slices/agentSlice.ts
+++ b/ui/src/store/slices/agentSlice.ts
@@ -144,7 +144,7 @@ export const createAgentSlice: StateCreator<StoreState, [], [], AgentSlice> = (
       await invoke("approve_agent_action", { approved: true });
       pushLog(`Approved: ${pendingApproval.toolName}`);
     } catch (err) {
-      pushLog(`Approval send failed: ${err}`);
+      pushLog(`Approval send failed: ${formatAgentError(err)}`);
     }
   },
 
@@ -156,7 +156,7 @@ export const createAgentSlice: StateCreator<StoreState, [], [], AgentSlice> = (
       await invoke("approve_agent_action", { approved: false });
       pushLog(`Rejected: ${pendingApproval.toolName}`);
     } catch (err) {
-      pushLog(`Rejection send failed: ${err}`);
+      pushLog(`Rejection send failed: ${formatAgentError(err)}`);
     }
   },
 


### PR DESCRIPTION
## Summary

Adds integration coverage for the agent runtime at the cross-task / cross-process coordination layer — the seam where the recent agent-hardening pass exposed races that engine-level unit tests could not reach.

Covered scenarios:

1. Stop during approval wait → terminal reason is `Replan` (explicit rejection), not `ApprovalUnavailable`.
2. Buffered events drained from run A cannot surface on run B.
3. Cached `launch_app` replay re-requests approval AND runs the post-tool hook (probe_app SubAction).
4. Native / no-CDP observations skip both cache read and cache write.
5. Workflow-mapping miss emits `Warning`, not `Error`; the run continues.
7. Spawn-window `force_stop` cancels the token even before a `task_handle` exists.
8. Concurrent `run_agent` rejections surface through the UI as `agentStatus=error` with the real `CommandError.message`, not `[object Object]`.

Also hardens `agentSlice.startAgent` / `approveAction` / `rejectAction` to extract `.message` from structured Tauri rejections via a `formatAgentError()` helper, and pins the contract with regression tests.

Scenario 6 (`begin_execution()` storage failure) is not covered — it lives inside the spawned Tauri task and needs either an `AppHandle` mock harness or a pure-helper extraction. Left for a follow-up; noted in the PR review.

## Test plan

- [x] `cargo test -p clickweave-engine` — all engine tests pass (including 5 new `coordination::*` scenarios).
- [x] `cargo test -p clickweave-tauri` — all Tauri tests pass (including 3 new `force_stop_*` cases).
- [x] `cd ui && npm test -- --run src/store/slices src/hooks` — all 64 frontend tests pass (including 6 new `agentSlice` cases).
- [x] `cd ui && npx tsc --noEmit` — clean typecheck.
- [x] Each new engine scenario verified to fail when the corresponding fix is reverted.