### PR TITLE
feat(engine): detect ambiguous CDP element matches with typed error

### DIFF
--- a/crates/clickweave-engine/src/executor/ambiguity.rs
+++ b/crates/clickweave-engine/src/executor/ambiguity.rs
@@ -40,6 +40,8 @@ struct SidecarRecord {
     chosen_uid: String,
     reasoning: String,
     candidates: Vec<CandidateView>,
+    viewport_width: f64,
+    viewport_height: f64,
     screenshot_path: String,
 }
 
@@ -107,6 +109,7 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
             &chosen_uid,
             &reasoning,
             &candidates_with_rects,
+            viewport,
             &screenshot_b64,
             node_run,
         );
@@ -198,6 +201,7 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
         chosen_uid: &str,
         reasoning: &str,
         candidates: &[CandidateView],
+        viewport: Viewport,
         screenshot_b64: &str,
         mut node_run: Option<&mut NodeRun>,
     ) -> String {
@@ -231,6 +235,8 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
                 chosen_uid: chosen_uid.to_string(),
                 reasoning: reasoning.to_string(),
                 candidates: candidates.to_vec(),
+                viewport_width: viewport.width,
+                viewport_height: viewport.height,
                 screenshot_path: screenshot_filename.clone(),
             };
             match serde_json::to_vec_pretty(&sidecar) {
@@ -257,6 +263,8 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
             "chosen_uid": chosen_uid,
             "reasoning": reasoning,
             "candidates": candidates,
+            "viewport_width": viewport.width,
+            "viewport_height": viewport.height,
             "screenshot_path": screenshot_filename,
         });
         if let Some(run) = node_run.as_deref() {

--- a/crates/clickweave-engine/src/executor/ambiguity.rs
+++ b/crates/clickweave-engine/src/executor/ambiguity.rs
@@ -1,0 +1,447 @@
+//! Agent-driven disambiguation for CDP targets that map to multiple snapshot
+//! lines.  When `resolve_cdp_element_uid` surfaces an `ExecutorError::
+//! CdpAmbiguousTarget`, this module captures a screenshot, reads each
+//! candidate's viewport rect via a single batched `Runtime.evaluate`, and asks
+//! the VLM to pick one.  The chosen uid is threaded back into the retry so the
+//! node completes on the next attempt.
+
+use super::error::{CandidateView, CdpCandidate, ExecutorError, ExecutorResult, Rect};
+use super::{Mcp, WorkflowExecutor};
+use clickweave_core::{ArtifactKind, NodeRun, TraceEvent, TraceLevel};
+use clickweave_llm::{ChatBackend, ChatOptions, Message};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use uuid::Uuid;
+
+/// Result of a successful agent disambiguation round.
+#[derive(Debug, Clone)]
+pub(crate) struct DisambiguationResult {
+    pub chosen_uid: String,
+    pub reasoning: String,
+    pub candidates_with_rects: Vec<CandidateView>,
+    /// Path to the captured screenshot, relative to the node's `artifacts/`
+    /// directory (the same base the UI consumes).
+    pub screenshot_path: String,
+    /// Raw base64-encoded PNG of the screenshot. Forwarded inline on the
+    /// executor event so the UI doesn't need to read the artifact from disk
+    /// while the run is still writing to it.
+    pub screenshot_base64: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct SidecarRecord {
+    target: String,
+    chosen_uid: String,
+    reasoning: String,
+    candidates: Vec<CandidateView>,
+    screenshot_path: String,
+}
+
+const DISAMBIGUATION_PROMPT: &str = "\
+You are helping a UI automation agent pick the correct element when its \
+accessibility-tree resolver matched more than one candidate for the same \
+target label.\n\n\
+You receive:\n\
+- The target label the agent tried to resolve.\n\
+- A screenshot of the page taken moments ago.\n\
+- A list of candidates: each has a uid, a snippet of the accessibility tree \
+line that matched, and the candidate's bounding rectangle in viewport \
+coordinates (x, y, width, height — in CSS pixels, top-left origin).\n\n\
+Pick the candidate that best matches what the agent likely meant. Prefer \
+candidates that are clearly visible, sit in a primary action area, and have \
+reasonable dimensions. Avoid candidates that are off-screen or zero-sized.\n\n\
+Respond with ONLY a JSON object (no markdown fences):\n\
+{\"chosen_uid\": \"<uid>\", \"reasoning\": \"<1-2 sentence justification>\"}";
+
+impl<C: ChatBackend> WorkflowExecutor<C> {
+    /// Run the full disambiguation routine and return the chosen uid plus the
+    /// candidate/rect data for the UI.
+    pub(crate) async fn resolve_cdp_ambiguity(
+        &self,
+        _node_id: Uuid,
+        node_name: &str,
+        target: &str,
+        candidates: Vec<CdpCandidate>,
+        mcp: &(impl Mcp + ?Sized),
+        node_run: Option<&mut NodeRun>,
+    ) -> ExecutorResult<DisambiguationResult> {
+        let screenshot_b64 = self
+            .capture_verification_screenshot(mcp)
+            .await
+            .ok_or_else(|| {
+                ExecutorError::Cdp(
+                    "Disambiguation: failed to capture screenshot for VLM prompt".to_string(),
+                )
+            })?;
+
+        let rects = fetch_candidate_rects(&candidates, mcp).await;
+        let candidates_with_rects: Vec<CandidateView> = candidates
+            .into_iter()
+            .zip(rects.into_iter())
+            .map(|(c, rect)| CandidateView {
+                uid: c.uid,
+                snippet: c.snippet,
+                rect,
+            })
+            .collect();
+
+        let (chosen_uid, reasoning) = self
+            .agent_pick_candidate(target, &screenshot_b64, &candidates_with_rects)
+            .await?;
+
+        if !candidates_with_rects.iter().any(|c| c.uid == chosen_uid) {
+            return Err(ExecutorError::Cdp(format!(
+                "Disambiguation: agent returned unknown uid '{}' for target '{}'",
+                chosen_uid, target
+            )));
+        }
+
+        let screenshot_path = self.persist_disambiguation_artifacts(
+            node_name,
+            target,
+            &chosen_uid,
+            &reasoning,
+            &candidates_with_rects,
+            &screenshot_b64,
+            node_run,
+        );
+
+        Ok(DisambiguationResult {
+            chosen_uid,
+            reasoning,
+            candidates_with_rects,
+            screenshot_path,
+            screenshot_base64: screenshot_b64,
+        })
+    }
+
+    /// Prompt the VLM and parse its structured choice.
+    async fn agent_pick_candidate(
+        &self,
+        target: &str,
+        screenshot_b64: &str,
+        candidates: &[CandidateView],
+    ) -> ExecutorResult<(String, String)> {
+        let vlm = self.vision_backend().unwrap_or(&self.agent);
+
+        let (prepared_b64, mime) = clickweave_llm::prepare_base64_image_for_vlm(
+            screenshot_b64,
+            clickweave_llm::DEFAULT_MAX_DIMENSION,
+        )
+        .ok_or_else(|| {
+            ExecutorError::Cdp("Disambiguation: failed to prepare screenshot for VLM".to_string())
+        })?;
+
+        let candidate_block = candidates
+            .iter()
+            .map(|c| {
+                let rect = c
+                    .rect
+                    .as_ref()
+                    .map(|r| {
+                        format!(
+                            "{{x: {:.1}, y: {:.1}, w: {:.1}, h: {:.1}}}",
+                            r.x, r.y, r.width, r.height
+                        )
+                    })
+                    .unwrap_or_else(|| "<rect unavailable>".to_string());
+                format!("- uid={}, snippet={}, rect={}", c.uid, c.snippet, rect)
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let user_text = format!(
+            "Target label: \"{}\"\n\nCandidates:\n{}",
+            target, candidate_block
+        );
+
+        let messages = vec![
+            Message::system(DISAMBIGUATION_PROMPT),
+            Message::user_with_images(user_text, vec![(prepared_b64, mime)]),
+        ];
+
+        let response = vlm
+            .chat_with_options(&messages, None, &ChatOptions::with_temperature(0.0))
+            .await
+            .map_err(|e| ExecutorError::Cdp(format!("Disambiguation: VLM call failed: {}", e)))?;
+
+        let raw = response
+            .choices
+            .first()
+            .and_then(|c| c.message.content_text())
+            .unwrap_or("")
+            .to_string();
+
+        parse_disambiguation_response(&raw).ok_or_else(|| {
+            ExecutorError::Cdp(format!(
+                "Disambiguation: failed to parse VLM response: {}",
+                raw
+            ))
+        })
+    }
+
+    /// Save the screenshot PNG plus a JSON sidecar describing the
+    /// disambiguation round into the node's `artifacts/` dir, and append the
+    /// trace event. Returns the screenshot path relative to that dir.
+    #[allow(clippy::too_many_arguments)]
+    fn persist_disambiguation_artifacts(
+        &self,
+        node_name: &str,
+        target: &str,
+        chosen_uid: &str,
+        reasoning: &str,
+        candidates: &[CandidateView],
+        screenshot_b64: &str,
+        mut node_run: Option<&mut NodeRun>,
+    ) -> String {
+        use base64::Engine;
+
+        let short = &Uuid::new_v4().to_string()[..8];
+        let screenshot_filename = format!("ambiguity_{}.png", short);
+        let sidecar_filename = format!("ambiguity_{}.json", short);
+
+        // Persist only when we have a trace-enabled NodeRun (same guard as
+        // `save_result_images`). Even without persistence we still emit the
+        // event; the UI will just fall back to a missing-screenshot placeholder.
+        if let Some(run) = node_run.as_deref_mut()
+            && run.trace_level != TraceLevel::Off
+        {
+            if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(screenshot_b64) {
+                match self.storage.save_artifact(
+                    run,
+                    ArtifactKind::Screenshot,
+                    &screenshot_filename,
+                    &bytes,
+                    Value::Null,
+                ) {
+                    Ok(artifact) => run.artifacts.push(artifact),
+                    Err(e) => tracing::warn!("Failed to save ambiguity screenshot: {}", e),
+                }
+            }
+
+            let sidecar = SidecarRecord {
+                target: target.to_string(),
+                chosen_uid: chosen_uid.to_string(),
+                reasoning: reasoning.to_string(),
+                candidates: candidates.to_vec(),
+                screenshot_path: screenshot_filename.clone(),
+            };
+            match serde_json::to_vec_pretty(&sidecar) {
+                Ok(bytes) => match self.storage.save_artifact(
+                    run,
+                    ArtifactKind::Other,
+                    &sidecar_filename,
+                    &bytes,
+                    Value::Null,
+                ) {
+                    Ok(artifact) => run.artifacts.push(artifact),
+                    Err(e) => tracing::warn!("Failed to save ambiguity sidecar: {}", e),
+                },
+                Err(e) => tracing::warn!("Failed to serialize ambiguity sidecar: {}", e),
+            }
+        }
+
+        // Append a structured trace event, whether or not the artifact writes
+        // succeeded — events.jsonl lives at the node run level and is the
+        // canonical record for post-run UI rendering.
+        let payload = serde_json::json!({
+            "node_name": node_name,
+            "target": target,
+            "chosen_uid": chosen_uid,
+            "reasoning": reasoning,
+            "candidates": candidates,
+            "screenshot_path": screenshot_filename,
+        });
+        if let Some(run) = node_run.as_deref() {
+            let event = TraceEvent {
+                timestamp: Self::now_millis(),
+                event_type: "ambiguity_resolved".to_string(),
+                payload,
+            };
+            if let Err(e) = self.storage.append_event(run, &event) {
+                tracing::warn!("Failed to append ambiguity_resolved event: {}", e);
+            }
+        }
+
+        screenshot_filename
+    }
+}
+
+/// Extract `{chosen_uid, reasoning}` from the VLM's reply, tolerating markdown
+/// fences and a leading/trailing natural-language sentence.
+fn parse_disambiguation_response(raw: &str) -> Option<(String, String)> {
+    let json_str = super::app_resolve::parse_llm_json_response(raw)?;
+    let value: Value = serde_json::from_str(json_str).ok()?;
+    let chosen = value.get("chosen_uid")?.as_str()?.to_string();
+    if chosen.is_empty() {
+        return None;
+    }
+    let reasoning = value
+        .get("reasoning")
+        .and_then(|v| v.as_str())
+        .unwrap_or("(no reasoning provided)")
+        .to_string();
+    Some((chosen, reasoning))
+}
+
+/// Batched `Runtime.evaluate` that returns a JSON array aligned 1:1 with
+/// `candidates`. Each entry is `{x, y, width, height}` or null. Falls back to
+/// per-candidate nulls when the CDP call fails.
+async fn fetch_candidate_rects(
+    candidates: &[CdpCandidate],
+    mcp: &(impl Mcp + ?Sized),
+) -> Vec<Option<Rect>> {
+    if candidates.is_empty() {
+        return Vec::new();
+    }
+
+    let uids_json = serde_json::to_string(
+        &candidates
+            .iter()
+            .map(|c| c.uid.as_str())
+            .collect::<Vec<_>>(),
+    )
+    .unwrap_or_else(|_| "[]".to_string());
+
+    let js = format!(
+        r#"(() => {{
+  const uids = {};
+  return uids.map((uid) => {{
+    try {{
+      let el = document.querySelector('[data-uid="' + uid + '"]') ||
+               document.querySelector('[uid="' + uid + '"]') ||
+               (typeof __cwResolveUid === 'function' ? __cwResolveUid(uid) : null);
+      if (!el) return null;
+      const r = el.getBoundingClientRect();
+      return {{ x: r.x, y: r.y, width: r.width, height: r.height }};
+    }} catch (e) {{
+      return null;
+    }}
+  }});
+}})()"#,
+        uids_json
+    );
+
+    let args = serde_json::json!({ "function": js });
+    let result = match mcp.call_tool("cdp_evaluate_script", Some(args)).await {
+        Ok(r) if r.is_error != Some(true) => r,
+        _ => return vec![None; candidates.len()],
+    };
+
+    let raw_text = result
+        .content
+        .iter()
+        .filter_map(|c| match c {
+            clickweave_mcp::ToolContent::Text { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("");
+
+    parse_rects_array(&raw_text, candidates.len())
+}
+
+/// Accept either a raw JSON array, a ```json-fenced array, or the
+/// `{"result": [...]}` wrapper chrome-devtools-mcp sometimes emits. Returns
+/// exactly `expected_len` entries, padding with `None` on parse failure.
+pub(crate) fn parse_rects_array(text: &str, expected_len: usize) -> Vec<Option<Rect>> {
+    let stripped = super::app_resolve::strip_code_block(text);
+    let value: Option<Value> = serde_json::from_str(stripped).ok();
+    let array: Option<&Vec<Value>> = value.as_ref().and_then(|v| {
+        v.as_array().or_else(|| {
+            // Some MCP implementations wrap the return value in {"result": ...}.
+            v.get("result").and_then(|r| r.as_array())
+        })
+    });
+
+    match array {
+        Some(arr) => {
+            let mut out: Vec<Option<Rect>> = arr
+                .iter()
+                .map(|entry| {
+                    let obj = entry.as_object()?;
+                    Some(Rect {
+                        x: obj.get("x")?.as_f64()?,
+                        y: obj.get("y")?.as_f64()?,
+                        width: obj.get("width")?.as_f64()?,
+                        height: obj.get("height")?.as_f64()?,
+                    })
+                })
+                .collect();
+            out.resize(expected_len, None);
+            out
+        }
+        None => vec![None; expected_len],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_disambiguation_response_accepts_plain_json() {
+        let (uid, reasoning) = parse_disambiguation_response(
+            r#"{"chosen_uid": "a5", "reasoning": "primary Save button in toolbar"}"#,
+        )
+        .expect("should parse");
+        assert_eq!(uid, "a5");
+        assert!(reasoning.contains("toolbar"));
+    }
+
+    #[test]
+    fn parse_disambiguation_response_accepts_fenced_json() {
+        let (uid, _) = parse_disambiguation_response(
+            "```json\n{\"chosen_uid\": \"a5\", \"reasoning\": \"x\"}\n```",
+        )
+        .expect("should parse fenced");
+        assert_eq!(uid, "a5");
+    }
+
+    #[test]
+    fn parse_disambiguation_response_rejects_missing_uid() {
+        assert!(parse_disambiguation_response(r#"{"reasoning": "no uid"}"#).is_none());
+    }
+
+    #[test]
+    fn parse_disambiguation_response_rejects_empty_uid() {
+        assert!(parse_disambiguation_response(r#"{"chosen_uid": "", "reasoning": "x"}"#).is_none());
+    }
+
+    #[test]
+    fn parse_disambiguation_response_fills_default_reasoning() {
+        let (uid, reasoning) =
+            parse_disambiguation_response(r#"{"chosen_uid": "a1"}"#).expect("should parse");
+        assert_eq!(uid, "a1");
+        assert!(reasoning.contains("no reasoning"));
+    }
+
+    #[test]
+    fn parse_rects_array_accepts_plain_array() {
+        let rects = parse_rects_array(
+            r#"[{"x": 1.0, "y": 2.0, "width": 3.0, "height": 4.0}, null]"#,
+            2,
+        );
+        assert_eq!(rects.len(), 2);
+        let r = rects[0].as_ref().expect("first rect");
+        assert_eq!(r.x, 1.0);
+        assert_eq!(r.width, 3.0);
+        assert!(rects[1].is_none());
+    }
+
+    #[test]
+    fn parse_rects_array_pads_with_none_on_parse_failure() {
+        assert_eq!(parse_rects_array("not json", 3).len(), 3);
+        assert!(parse_rects_array("not json", 3).iter().all(|e| e.is_none()));
+    }
+
+    #[test]
+    fn parse_rects_array_unwraps_result_envelope() {
+        let rects = parse_rects_array(
+            r#"{"result": [{"x": 10.0, "y": 20.0, "width": 30.0, "height": 40.0}]}"#,
+            1,
+        );
+        let r = rects[0].as_ref().expect("rect present");
+        assert_eq!(r.x, 10.0);
+    }
+}

--- a/crates/clickweave-engine/src/executor/ambiguity.rs
+++ b/crates/clickweave-engine/src/executor/ambiguity.rs
@@ -58,7 +58,6 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
     /// candidate/rect data for the UI.
     pub(crate) async fn resolve_cdp_ambiguity(
         &self,
-        _node_id: Uuid,
         node_name: &str,
         target: &str,
         candidates: Vec<CdpCandidate>,

--- a/crates/clickweave-engine/src/executor/ambiguity.rs
+++ b/crates/clickweave-engine/src/executor/ambiguity.rs
@@ -19,6 +19,12 @@ pub(crate) struct DisambiguationResult {
     pub chosen_uid: String,
     pub reasoning: String,
     pub candidates_with_rects: Vec<CandidateView>,
+    /// Viewport dimensions at capture time. The UI uses these to translate
+    /// the CDP-viewport rects (CSS pixels, origin at viewport top-left) into
+    /// image-pixel coordinates inside the captured screenshot, which may
+    /// include chrome (tab bar, title bar) above/around the viewport.
+    pub viewport_width: f64,
+    pub viewport_height: f64,
     /// Path to the captured screenshot, relative to the node's `artifacts/`
     /// directory (the same base the UI consumes).
     pub screenshot_path: String,
@@ -73,7 +79,7 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
                 )
             })?;
 
-        let rects = fetch_candidate_rects(&candidates, mcp).await;
+        let (viewport, rects) = fetch_candidate_rects(&candidates, mcp).await;
         let candidates_with_rects: Vec<CandidateView> = candidates
             .into_iter()
             .zip(rects.into_iter())
@@ -109,6 +115,8 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
             chosen_uid,
             reasoning,
             candidates_with_rects,
+            viewport_width: viewport.width,
+            viewport_height: viewport.height,
             screenshot_path,
             screenshot_base64: screenshot_b64,
         })
@@ -283,15 +291,24 @@ fn parse_disambiguation_response(raw: &str) -> Option<(String, String)> {
     Some((chosen, reasoning))
 }
 
-/// Batched `Runtime.evaluate` that returns a JSON array aligned 1:1 with
-/// `candidates`. Each entry is `{x, y, width, height}` or null. Falls back to
-/// per-candidate nulls when the CDP call fails.
+/// Viewport dimensions reported alongside the rects so the UI can translate
+/// CDP-viewport coordinates into image-pixel coordinates when the captured
+/// screenshot includes window chrome (OS title bar, browser toolbar, etc.).
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct Viewport {
+    pub width: f64,
+    pub height: f64,
+}
+
+/// Batched `Runtime.evaluate` that returns viewport dimensions plus a rect for
+/// each candidate uid (or null for uids it can't locate). Falls back to
+/// per-candidate nulls + zero-sized viewport when the CDP call fails.
 async fn fetch_candidate_rects(
     candidates: &[CdpCandidate],
     mcp: &(impl Mcp + ?Sized),
-) -> Vec<Option<Rect>> {
+) -> (Viewport, Vec<Option<Rect>>) {
     if candidates.is_empty() {
-        return Vec::new();
+        return (Viewport::default(), Vec::new());
     }
 
     let uids_json = serde_json::to_string(
@@ -305,7 +322,7 @@ async fn fetch_candidate_rects(
     let js = format!(
         r#"(() => {{
   const uids = {};
-  return uids.map((uid) => {{
+  const rects = uids.map((uid) => {{
     try {{
       let el = document.querySelector('[data-uid="' + uid + '"]') ||
                document.querySelector('[uid="' + uid + '"]') ||
@@ -317,6 +334,10 @@ async fn fetch_candidate_rects(
       return null;
     }}
   }});
+  return {{
+    viewport: {{ width: window.innerWidth, height: window.innerHeight }},
+    rects: rects,
+  }};
 }})()"#,
         uids_json
     );
@@ -324,7 +345,7 @@ async fn fetch_candidate_rects(
     let args = serde_json::json!({ "function": js });
     let result = match mcp.call_tool("cdp_evaluate_script", Some(args)).await {
         Ok(r) if r.is_error != Some(true) => r,
-        _ => return vec![None; candidates.len()],
+        _ => return (Viewport::default(), vec![None; candidates.len()]),
     };
 
     let raw_text = result
@@ -337,41 +358,66 @@ async fn fetch_candidate_rects(
         .collect::<Vec<_>>()
         .join("");
 
-    parse_rects_array(&raw_text, candidates.len())
+    parse_candidate_rects_response(&raw_text, candidates.len())
 }
 
-/// Accept either a raw JSON array, a ```json-fenced array, or the
-/// `{"result": [...]}` wrapper chrome-devtools-mcp sometimes emits. Returns
-/// exactly `expected_len` entries, padding with `None` on parse failure.
-pub(crate) fn parse_rects_array(text: &str, expected_len: usize) -> Vec<Option<Rect>> {
+/// Accept either the new `{viewport, rects}` envelope, a raw rects array, a
+/// ```json-fenced array, or the `{"result": [...]}` wrapper chrome-devtools-mcp
+/// sometimes emits. Returns exactly `expected_len` rects, padding with `None`
+/// on parse failure. Viewport defaults to zeros when unavailable.
+pub(crate) fn parse_candidate_rects_response(
+    text: &str,
+    expected_len: usize,
+) -> (Viewport, Vec<Option<Rect>>) {
     let stripped = super::app_resolve::strip_code_block(text);
-    let value: Option<Value> = serde_json::from_str(stripped).ok();
-    let array: Option<&Vec<Value>> = value.as_ref().and_then(|v| {
-        v.as_array().or_else(|| {
-            // Some MCP implementations wrap the return value in {"result": ...}.
-            v.get("result").and_then(|r| r.as_array())
-        })
-    });
+    let Ok(value): Result<Value, _> = serde_json::from_str(stripped) else {
+        return (Viewport::default(), vec![None; expected_len]);
+    };
 
-    match array {
-        Some(arr) => {
-            let mut out: Vec<Option<Rect>> = arr
-                .iter()
-                .map(|entry| {
-                    let obj = entry.as_object()?;
-                    Some(Rect {
-                        x: obj.get("x")?.as_f64()?,
-                        y: obj.get("y")?.as_f64()?,
-                        width: obj.get("width")?.as_f64()?,
-                        height: obj.get("height")?.as_f64()?,
-                    })
+    // Unwrap an optional `{"result": ...}` envelope first.
+    let inner = value.get("result").unwrap_or(&value);
+
+    // Case 1: `{ viewport: {w,h}, rects: [...] }`
+    if let Some(obj) = inner.as_object()
+        && let Some(rects_val) = obj.get("rects")
+        && let Some(arr) = rects_val.as_array()
+    {
+        let viewport = obj
+            .get("viewport")
+            .and_then(|v| v.as_object())
+            .and_then(|vp| {
+                Some(Viewport {
+                    width: vp.get("width")?.as_f64()?,
+                    height: vp.get("height")?.as_f64()?,
                 })
-                .collect();
-            out.resize(expected_len, None);
-            out
-        }
-        None => vec![None; expected_len],
+            })
+            .unwrap_or_default();
+        return (viewport, parse_rects_only(arr, expected_len));
     }
+
+    // Case 2: a bare rects array (used by tests and legacy clients).
+    if let Some(arr) = inner.as_array() {
+        return (Viewport::default(), parse_rects_only(arr, expected_len));
+    }
+
+    (Viewport::default(), vec![None; expected_len])
+}
+
+fn parse_rects_only(arr: &[Value], expected_len: usize) -> Vec<Option<Rect>> {
+    let mut out: Vec<Option<Rect>> = arr
+        .iter()
+        .map(|entry| {
+            let obj = entry.as_object()?;
+            Some(Rect {
+                x: obj.get("x")?.as_f64()?,
+                y: obj.get("y")?.as_f64()?,
+                width: obj.get("width")?.as_f64()?,
+                height: obj.get("height")?.as_f64()?,
+            })
+        })
+        .collect();
+    out.resize(expected_len, None);
+    out
 }
 
 #[cfg(test)]
@@ -416,8 +462,8 @@ mod tests {
     }
 
     #[test]
-    fn parse_rects_array_accepts_plain_array() {
-        let rects = parse_rects_array(
+    fn parse_candidate_rects_response_accepts_bare_array() {
+        let (vp, rects) = parse_candidate_rects_response(
             r#"[{"x": 1.0, "y": 2.0, "width": 3.0, "height": 4.0}, null]"#,
             2,
         );
@@ -426,21 +472,54 @@ mod tests {
         assert_eq!(r.x, 1.0);
         assert_eq!(r.width, 3.0);
         assert!(rects[1].is_none());
+        // Bare arrays carry no viewport info.
+        assert_eq!(vp.width, 0.0);
+        assert_eq!(vp.height, 0.0);
     }
 
     #[test]
-    fn parse_rects_array_pads_with_none_on_parse_failure() {
-        assert_eq!(parse_rects_array("not json", 3).len(), 3);
-        assert!(parse_rects_array("not json", 3).iter().all(|e| e.is_none()));
+    fn parse_candidate_rects_response_pads_with_none_on_parse_failure() {
+        let (_, rects) = parse_candidate_rects_response("not json", 3);
+        assert_eq!(rects.len(), 3);
+        assert!(rects.iter().all(|e| e.is_none()));
     }
 
     #[test]
-    fn parse_rects_array_unwraps_result_envelope() {
-        let rects = parse_rects_array(
+    fn parse_candidate_rects_response_unwraps_result_envelope() {
+        let (_, rects) = parse_candidate_rects_response(
             r#"{"result": [{"x": 10.0, "y": 20.0, "width": 30.0, "height": 40.0}]}"#,
             1,
         );
         let r = rects[0].as_ref().expect("rect present");
         assert_eq!(r.x, 10.0);
+    }
+
+    #[test]
+    fn parse_candidate_rects_response_extracts_viewport_from_envelope() {
+        let (vp, rects) = parse_candidate_rects_response(
+            r#"{
+                "viewport": {"width": 1280.0, "height": 720.0},
+                "rects": [{"x": 5.0, "y": 6.0, "width": 7.0, "height": 8.0}]
+            }"#,
+            1,
+        );
+        assert_eq!(vp.width, 1280.0);
+        assert_eq!(vp.height, 720.0);
+        assert_eq!(rects[0].as_ref().unwrap().x, 5.0);
+    }
+
+    #[test]
+    fn parse_candidate_rects_response_extracts_viewport_inside_result_wrapper() {
+        let (vp, rects) = parse_candidate_rects_response(
+            r#"{"result": {
+                "viewport": {"width": 800.0, "height": 600.0},
+                "rects": []
+            }}"#,
+            2,
+        );
+        assert_eq!(vp.width, 800.0);
+        assert_eq!(vp.height, 600.0);
+        assert_eq!(rects.len(), 2);
+        assert!(rects.iter().all(|r| r.is_none()));
     }
 }

--- a/crates/clickweave-engine/src/executor/deterministic/cdp.rs
+++ b/crates/clickweave-engine/src/executor/deterministic/cdp.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use super::super::retry_context::RetryContext;
-use super::super::{ExecutorError, ExecutorResult, Mcp, WorkflowExecutor};
+use super::super::{CdpCandidate, ExecutorError, ExecutorResult, Mcp, WorkflowExecutor};
 use clickweave_core::NodeRun;
 use clickweave_llm::ChatBackend;
 use uuid::Uuid;
@@ -54,22 +54,28 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
             }
 
             let snapshot_text = Self::extract_result_text(&snapshot_result);
-            let target_lower = target.to_lowercase();
+            let candidates = collect_snapshot_candidates(&snapshot_text, target);
 
-            // Simple search: find lines containing the target text and a UID.
-            for line in snapshot_text.lines() {
-                let Some(uid) = Self::parse_snapshot_uid(line) else {
-                    continue;
-                };
-                // Skip leaf text nodes.
-                let after_uid = line.trim_start();
-                if after_uid.contains("StaticText") || after_uid.contains("InlineTextBox") {
-                    continue;
-                }
-                // Check if the line label contains the target.
-                if line.to_lowercase().contains(&target_lower) {
+            match candidates.len() {
+                0 => continue,
+                1 => {
+                    let uid = candidates
+                        .into_iter()
+                        .next()
+                        .map(|c| c.uid)
+                        .unwrap_or_default();
                     self.log(format!("CDP: resolved '{}' -> uid='{}'", target, uid));
                     return Ok(uid);
+                }
+                n => {
+                    self.log(format!(
+                        "CDP: ambiguous target '{}' matched {} elements",
+                        target, n
+                    ));
+                    return Err(ExecutorError::CdpAmbiguousTarget {
+                        target: target.to_string(),
+                        candidates,
+                    });
                 }
             }
         }
@@ -78,28 +84,6 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
             "No matching element for '{}' in CDP snapshot",
             target
         )))
-    }
-
-    /// Parse a UID from a CDP snapshot line.
-    /// Handles both `uid=1_0 ...` and `[uid="e1"] ...` formats.
-    fn parse_snapshot_uid(line: &str) -> Option<String> {
-        let uid_pos = line.find("uid=")?;
-        let rest = &line[uid_pos + 4..];
-        if let Some(quoted) = rest.strip_prefix('"') {
-            let end = quoted.find('"')?;
-            let uid = &quoted[..end];
-            if uid.is_empty() {
-                return None;
-            }
-            Some(uid.to_string())
-        } else {
-            let end = rest.find(' ').unwrap_or(rest.len());
-            let uid = &rest[..end];
-            if uid.is_empty() {
-                return None;
-            }
-            Some(uid.to_string())
-        }
     }
 
     /// Resolve a CDP element and perform an action (click or hover) on it.
@@ -520,6 +504,52 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
     }
 }
 
+/// Parse a UID from a CDP snapshot line.
+/// Handles both `uid=1_0 ...` and `[uid="e1"] ...` formats.
+fn parse_snapshot_uid(line: &str) -> Option<String> {
+    let uid_pos = line.find("uid=")?;
+    let rest = &line[uid_pos + 4..];
+    if let Some(quoted) = rest.strip_prefix('"') {
+        let end = quoted.find('"')?;
+        let uid = &quoted[..end];
+        if uid.is_empty() {
+            return None;
+        }
+        Some(uid.to_string())
+    } else {
+        let end = rest.find(' ').unwrap_or(rest.len());
+        let uid = &rest[..end];
+        if uid.is_empty() {
+            return None;
+        }
+        Some(uid.to_string())
+    }
+}
+
+/// Scan a CDP snapshot for lines whose label contains `target` (case-insensitive)
+/// and carry a UID. Leaf text nodes (`StaticText`, `InlineTextBox`) are skipped
+/// — those repeat the parent's label and would inflate the candidate count.
+fn collect_snapshot_candidates(snapshot_text: &str, target: &str) -> Vec<CdpCandidate> {
+    let target_lower = target.to_lowercase();
+    let mut out = Vec::new();
+    for line in snapshot_text.lines() {
+        let Some(uid) = parse_snapshot_uid(line) else {
+            continue;
+        };
+        let after_uid = line.trim_start();
+        if after_uid.contains("StaticText") || after_uid.contains("InlineTextBox") {
+            continue;
+        }
+        if line.to_lowercase().contains(&target_lower) {
+            out.push(CdpCandidate {
+                uid,
+                snippet: after_uid.to_string(),
+            });
+        }
+    }
+    out
+}
+
 /// Detect UID-shaped strings: an AX/DOM prefix letter plus digits (`a5`, `d12`,
 /// `e1`), or a two-number backend-node form (`1_0`). Anything else is treated
 /// as a human-visible label or intent that must be re-resolved at runtime.
@@ -680,7 +710,10 @@ fn windows_process_image_candidates(app_name: &str) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{looks_like_cdp_uid, windows_process_image_candidates};
+    use super::{
+        collect_snapshot_candidates, looks_like_cdp_uid, parse_snapshot_uid,
+        windows_process_image_candidates,
+    };
 
     #[test]
     fn looks_like_cdp_uid_accepts_prefixed_form() {
@@ -730,5 +763,50 @@ mod tests {
             windows_process_image_candidates("Some App"),
             vec!["Some App.exe".to_string()]
         );
+    }
+
+    #[test]
+    fn parse_snapshot_uid_handles_both_formats() {
+        assert_eq!(
+            parse_snapshot_uid("[uid=\"a5\"] button \"Submit\""),
+            Some("a5".to_string())
+        );
+        assert_eq!(
+            parse_snapshot_uid("  uid=1_0 button \"Submit\""),
+            Some("1_0".to_string())
+        );
+        assert_eq!(parse_snapshot_uid("no uid here"), None);
+    }
+
+    #[test]
+    fn collect_snapshot_candidates_skips_leaf_text_nodes() {
+        let snapshot = concat!(
+            "[uid=\"a1\"] button \"Submit\"\n",
+            "[uid=\"a2\"] StaticText \"Submit\"\n",
+            "[uid=\"a3\"] InlineTextBox \"Submit\"\n",
+        );
+        let candidates = collect_snapshot_candidates(snapshot, "Submit");
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].uid, "a1");
+    }
+
+    #[test]
+    fn collect_snapshot_candidates_matches_case_insensitively() {
+        let snapshot = "[uid=\"a1\"] button \"Submit\"";
+        assert_eq!(collect_snapshot_candidates(snapshot, "submit").len(), 1);
+        assert_eq!(collect_snapshot_candidates(snapshot, "SUBMIT").len(), 1);
+    }
+
+    #[test]
+    fn collect_snapshot_candidates_returns_all_matches_for_disambiguation() {
+        let snapshot = concat!(
+            "[uid=\"a1\"] button \"Save\"\n",
+            "[uid=\"a2\"] button \"Save\"\n",
+            "[uid=\"a3\"] button \"Save\"\n",
+        );
+        let candidates = collect_snapshot_candidates(snapshot, "Save");
+        assert_eq!(candidates.len(), 3);
+        let uids: Vec<_> = candidates.iter().map(|c| c.uid.as_str()).collect();
+        assert_eq!(uids, vec!["a1", "a2", "a3"]);
     }
 }

--- a/crates/clickweave-engine/src/executor/deterministic/cdp.rs
+++ b/crates/clickweave-engine/src/executor/deterministic/cdp.rs
@@ -10,15 +10,40 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
     /// Simple element resolution: take a snapshot, find the first matching
     /// element by text, and return its UID. No LLM disambiguation or
     /// multi-tier fallbacks — the agent architecture handles that.
+    #[cfg(test)]
     pub(in crate::executor) async fn resolve_cdp_element_uid(
         &self,
         target: &str,
         mcp: &(impl Mcp + ?Sized),
     ) -> ExecutorResult<String> {
+        self.resolve_cdp_element_uid_with_overrides(target, mcp, None)
+            .await
+    }
+
+    /// Variant that lets the caller pass a target→uid override map. When an
+    /// override is present for `target`, the snapshot/MCP round-trip is
+    /// skipped and the pre-chosen uid is returned directly. Used by the
+    /// agent-disambiguation retry path.
+    pub(in crate::executor) async fn resolve_cdp_element_uid_with_overrides(
+        &self,
+        target: &str,
+        mcp: &(impl Mcp + ?Sized),
+        overrides: Option<&RetryContext>,
+    ) -> ExecutorResult<String> {
         if target.trim().is_empty() {
             return Err(ExecutorError::Cdp(
                 "CDP target is empty; expected a non-empty label or text".to_string(),
             ));
+        }
+
+        if let Some(ctx) = overrides
+            && let Some(uid) = ctx.read_cdp_ambiguity_overrides().get(target).cloned()
+        {
+            self.log(format!(
+                "CDP: using agent-picked uid='{}' for '{}' (ambiguity override)",
+                uid, target
+            ));
+            return Ok(uid);
         }
 
         // Refresh page list to verify CDP connection is healthy.
@@ -90,9 +115,11 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
         target: &str,
         mcp: &(impl Mcp + ?Sized),
         node_run: Option<&NodeRun>,
-        _retry_ctx: &RetryContext,
+        retry_ctx: &RetryContext,
     ) -> ExecutorResult<String> {
-        let uid = self.resolve_cdp_element_uid(target, mcp).await?;
+        let uid = self
+            .resolve_cdp_element_uid_with_overrides(target, mcp, Some(retry_ctx))
+            .await?;
 
         self.log(format!("CDP: {} element uid='{}'", action, uid));
         let result = mcp
@@ -137,17 +164,35 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
     /// UID-only tools. `ResolvedUid` and obvious UID-shaped labels pass through
     /// untouched; `Intent` and free-form labels go through snapshot resolution
     /// so the UID is refreshed against the live DOM.
+    #[cfg(test)]
     pub(in crate::executor) async fn resolve_cdp_target_uid(
         &self,
         target: &clickweave_core::CdpTarget,
         mcp: &(impl Mcp + ?Sized),
     ) -> ExecutorResult<String> {
+        self.resolve_cdp_target_uid_with_overrides(target, mcp, None)
+            .await
+    }
+
+    /// Override-aware variant of `resolve_cdp_target_uid`.
+    pub(in crate::executor) async fn resolve_cdp_target_uid_with_overrides(
+        &self,
+        target: &clickweave_core::CdpTarget,
+        mcp: &(impl Mcp + ?Sized),
+        overrides: Option<&RetryContext>,
+    ) -> ExecutorResult<String> {
         use clickweave_core::CdpTarget;
         match target {
             CdpTarget::ResolvedUid(uid) => Ok(uid.clone()),
             CdpTarget::ExactLabel(s) if looks_like_cdp_uid(s) => Ok(s.clone()),
-            CdpTarget::ExactLabel(label) => self.resolve_cdp_element_uid(label, mcp).await,
-            CdpTarget::Intent(intent) => self.resolve_cdp_element_uid(intent, mcp).await,
+            CdpTarget::ExactLabel(label) => {
+                self.resolve_cdp_element_uid_with_overrides(label, mcp, overrides)
+                    .await
+            }
+            CdpTarget::Intent(intent) => {
+                self.resolve_cdp_element_uid_with_overrides(intent, mcp, overrides)
+                    .await
+            }
         }
     }
 

--- a/crates/clickweave-engine/src/executor/deterministic/cdp.rs
+++ b/crates/clickweave-engine/src/executor/deterministic/cdp.rs
@@ -54,30 +54,25 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
             }
 
             let snapshot_text = Self::extract_result_text(&snapshot_result);
-            let candidates = collect_snapshot_candidates(&snapshot_text, target);
+            let mut candidates = collect_snapshot_candidates(&snapshot_text, target);
 
-            match candidates.len() {
-                0 => continue,
-                1 => {
-                    let uid = candidates
-                        .into_iter()
-                        .next()
-                        .map(|c| c.uid)
-                        .unwrap_or_default();
-                    self.log(format!("CDP: resolved '{}' -> uid='{}'", target, uid));
-                    return Ok(uid);
-                }
-                n => {
-                    self.log(format!(
-                        "CDP: ambiguous target '{}' matched {} elements",
-                        target, n
-                    ));
-                    return Err(ExecutorError::CdpAmbiguousTarget {
-                        target: target.to_string(),
-                        candidates,
-                    });
-                }
+            if candidates.is_empty() {
+                continue;
             }
+            if candidates.len() == 1 {
+                let uid = candidates.swap_remove(0).uid;
+                self.log(format!("CDP: resolved '{}' -> uid='{}'", target, uid));
+                return Ok(uid);
+            }
+            self.log(format!(
+                "CDP: ambiguous target '{}' matched {} elements",
+                target,
+                candidates.len()
+            ));
+            return Err(ExecutorError::CdpAmbiguousTarget {
+                target: target.to_string(),
+                candidates,
+            });
         }
 
         Err(ExecutorError::Cdp(format!(

--- a/crates/clickweave-engine/src/executor/deterministic/mod.rs
+++ b/crates/clickweave-engine/src/executor/deterministic/mod.rs
@@ -471,7 +471,9 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
         // CDP Fill: resolve target against the live snapshot so a UID baked in
         // at planning time stays valid after relaunch.
         if let NodeType::CdpFill(p) = node_type {
-            let uid = self.resolve_cdp_target_uid(&p.target, mcp).await?;
+            let uid = self
+                .resolve_cdp_target_uid_with_overrides(&p.target, mcp, Some(retry_ctx))
+                .await?;
             let args = serde_json::json!({"uid": uid, "value": p.value});
             self.record_event(
                 node_run.as_deref(),

--- a/crates/clickweave-engine/src/executor/error.rs
+++ b/crates/clickweave-engine/src/executor/error.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// A single snapshot line that matched the resolver target, retained so the
@@ -8,6 +9,25 @@ pub struct CdpCandidate {
     pub uid: String,
     /// The full snapshot line, trimmed, for context.
     pub snippet: String,
+}
+
+/// Viewport rectangle of a candidate element, expressed in CSS pixels relative
+/// to the top-left of the page viewport.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Rect {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+}
+
+/// Extended candidate record carrying its viewport rect so the UI can draw
+/// overlays. Used by the `AmbiguityResolved` executor event.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CandidateView {
+    pub uid: String,
+    pub snippet: String,
+    pub rect: Option<Rect>,
 }
 
 #[derive(Debug, Error)]

--- a/crates/clickweave-engine/src/executor/error.rs
+++ b/crates/clickweave-engine/src/executor/error.rs
@@ -1,5 +1,15 @@
 use thiserror::Error;
 
+/// A single snapshot line that matched the resolver target, retained so the
+/// agent loop (or a human reading the error) can disambiguate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CdpCandidate {
+    /// UID parsed from the snapshot line (e.g. `a5`, `1_0`).
+    pub uid: String,
+    /// The full snapshot line, trimmed, for context.
+    pub snippet: String,
+}
+
 #[derive(Debug, Error)]
 pub enum ExecutorError {
     #[error("LLM error: {0}")]
@@ -19,6 +29,16 @@ pub enum ExecutorError {
 
     #[error("CDP error: {0}")]
     Cdp(String),
+
+    #[error(
+        "Ambiguous CDP target '{target}': {} candidates matched — {}",
+        candidates.len(),
+        candidates.iter().map(|c| format!("uid={} ({})", c.uid, c.snippet)).collect::<Vec<_>>().join("; ")
+    )]
+    CdpAmbiguousTarget {
+        target: String,
+        candidates: Vec<CdpCandidate>,
+    },
 
     #[error("Validation error: {0}")]
     Validation(String),

--- a/crates/clickweave-engine/src/executor/error.rs
+++ b/crates/clickweave-engine/src/executor/error.rs
@@ -31,9 +31,9 @@ pub enum ExecutorError {
     Cdp(String),
 
     #[error(
-        "Ambiguous CDP target '{target}': {} candidates matched — {}",
+        "Ambiguous CDP target '{target}': {} candidates matched (uids: {})",
         candidates.len(),
-        candidates.iter().map(|c| format!("uid={} ({})", c.uid, c.snippet)).collect::<Vec<_>>().join("; ")
+        candidates.iter().map(|c| c.uid.as_str()).collect::<Vec<_>>().join(", ")
     )]
     CdpAmbiguousTarget {
         target: String,

--- a/crates/clickweave-engine/src/executor/mod.rs
+++ b/crates/clickweave-engine/src/executor/mod.rs
@@ -1,5 +1,6 @@
 mod action_verification;
 mod ai_step;
+pub(crate) mod ambiguity;
 mod app_resolve;
 mod cdp_wait;
 pub(crate) mod deterministic;
@@ -111,6 +112,25 @@ pub enum ExecutorEvent {
         finding: String,
         /// Base64-encoded screenshot captured during verification, if available.
         screenshot: Option<String>,
+    },
+    /// Agent picked one candidate from an ambiguous CDP resolver match.
+    /// Fires after the agent commits to a choice; the run loop continues with
+    /// the chosen uid. The UI renders this as a persistent card with a modal
+    /// that overlays each candidate's rect on top of the captured screenshot.
+    AmbiguityResolved {
+        node_id: Uuid,
+        target: String,
+        candidates: Vec<CandidateView>,
+        chosen_uid: String,
+        reasoning: String,
+        /// Screenshot filename relative to the node's `artifacts/` directory.
+        /// The UI reads the live base64 from `screenshot_base64`; this path is
+        /// for post-run re-rendering via the trace event.
+        screenshot_path: String,
+        /// Base64-encoded PNG of the screenshot taken at decision time. Sent
+        /// inline so the UI can render the modal immediately without a
+        /// separate filesystem read.
+        screenshot_base64: String,
     },
     NodeCancelled(Uuid),
 }

--- a/crates/clickweave-engine/src/executor/mod.rs
+++ b/crates/clickweave-engine/src/executor/mod.rs
@@ -123,6 +123,12 @@ pub enum ExecutorEvent {
         candidates: Vec<CandidateView>,
         chosen_uid: String,
         reasoning: String,
+        /// Viewport dimensions (CSS pixels) at capture time. Used by the UI
+        /// overlay to translate candidate rects — which are viewport-relative
+        /// — into image-pixel coordinates when the screenshot includes
+        /// chrome (title bar, tab bar) around the viewport.
+        viewport_width: f64,
+        viewport_height: f64,
         /// Screenshot filename relative to the node's `artifacts/` directory.
         /// The UI reads the live base64 from `screenshot_base64`; this path is
         /// for post-run re-rendering via the trace event.

--- a/crates/clickweave-engine/src/executor/retry_context.rs
+++ b/crates/clickweave-engine/src/executor/retry_context.rs
@@ -1,5 +1,6 @@
 use clickweave_core::NodeVerdict;
 use clickweave_llm::Message;
+use std::collections::HashMap;
 use std::sync::RwLock;
 use uuid::Uuid;
 
@@ -50,6 +51,12 @@ pub(crate) struct RetryContext {
     /// Set by deterministic execution, read by supervision to include
     /// actual-vs-intended comparison in the step message.
     pub last_tool_result: Option<String>,
+
+    /// Agent-picked UID overrides for CDP targets whose snapshot was ambiguous.
+    /// Keyed by the resolver target string; the CDP resolver consults this map
+    /// before taking a snapshot so the follow-up retry clicks the chosen
+    /// element instead of re-raising the same ambiguity error.
+    pub cdp_ambiguity_overrides: RwLock<HashMap<String, String>>,
 }
 
 impl RetryContext {
@@ -65,7 +72,24 @@ impl RetryContext {
             force_resolve: false,
             focus_dirty: false,
             last_tool_result: None,
+            cdp_ambiguity_overrides: RwLock::new(HashMap::new()),
         }
+    }
+
+    pub fn read_cdp_ambiguity_overrides(
+        &self,
+    ) -> std::sync::RwLockReadGuard<'_, HashMap<String, String>> {
+        self.cdp_ambiguity_overrides
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+    }
+
+    pub fn write_cdp_ambiguity_overrides(
+        &self,
+    ) -> std::sync::RwLockWriteGuard<'_, HashMap<String, String>> {
+        self.cdp_ambiguity_overrides
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
     }
 
     // ── RwLock helpers ───────────────────────────────────────────────────

--- a/crates/clickweave-engine/src/executor/run_loop.rs
+++ b/crates/clickweave-engine/src/executor/run_loop.rs
@@ -420,7 +420,6 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
                     ));
                     match self
                         .resolve_cdp_ambiguity(
-                            node_id,
                             node_name,
                             &target,
                             candidates,
@@ -434,10 +433,7 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
                                 "Agent picked uid='{}' for '{}': {}",
                                 res.chosen_uid,
                                 target,
-                                super::WorkflowExecutor::<C>::truncate_for_trace(
-                                    &res.reasoning,
-                                    200
-                                )
+                                Self::truncate_for_trace(&res.reasoning, 200)
                             ));
                             ctx.write_cdp_ambiguity_overrides()
                                 .insert(target.clone(), res.chosen_uid.clone());

--- a/crates/clickweave-engine/src/executor/run_loop.rs
+++ b/crates/clickweave-engine/src/executor/run_loop.rs
@@ -334,6 +334,11 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
                                 verification.reasoning,
                             ));
                             ctx.supervision_hint = Some(verification.reasoning.clone());
+                            // Drop the prior agent pick so the supervision
+                            // hint can drive a different disambiguation on
+                            // the retry. Without this, the resolver would
+                            // short-circuit on the stale override.
+                            ctx.write_cdp_ambiguity_overrides().clear();
                             self.evict_caches_for_node(node_type);
                             ctx.force_resolve = true;
                             self.record_event(

--- a/crates/clickweave-engine/src/executor/run_loop.rs
+++ b/crates/clickweave-engine/src/executor/run_loop.rs
@@ -395,6 +395,74 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
                     self.emit(ExecutorEvent::NodeCancelled(node_id));
                     return StepOutcome::Cancelled;
                 }
+                Err(ExecutorError::CdpAmbiguousTarget { target, candidates }) => {
+                    // Agent-driven disambiguation: pick one candidate, stash
+                    // the uid in the retry context, and re-run the node so the
+                    // resolver short-circuits to the chosen uid.
+                    let already_tried = ctx.read_cdp_ambiguity_overrides().contains_key(&target);
+                    if already_tried {
+                        let msg = format!(
+                            "Disambiguation already attempted for '{}' but resolver remained ambiguous",
+                            target
+                        );
+                        self.emit_error(format!("Node {} failed: {}", node_name, msg));
+                        if let Some(run) = node_run {
+                            self.finalize_run(run, RunStatus::Failed);
+                        }
+                        self.emit(ExecutorEvent::NodeFailed(node_id, msg));
+                        return StepOutcome::Failed;
+                    }
+
+                    self.log(format!(
+                        "Ambiguous CDP target '{}' — asking agent to pick among {} candidates",
+                        target,
+                        candidates.len()
+                    ));
+                    match self
+                        .resolve_cdp_ambiguity(
+                            node_id,
+                            node_name,
+                            &target,
+                            candidates,
+                            mcp,
+                            node_run.as_mut(),
+                        )
+                        .await
+                    {
+                        Ok(res) => {
+                            self.log(format!(
+                                "Agent picked uid='{}' for '{}': {}",
+                                res.chosen_uid,
+                                target,
+                                super::WorkflowExecutor::<C>::truncate_for_trace(
+                                    &res.reasoning,
+                                    200
+                                )
+                            ));
+                            ctx.write_cdp_ambiguity_overrides()
+                                .insert(target.clone(), res.chosen_uid.clone());
+                            self.emit(ExecutorEvent::AmbiguityResolved {
+                                node_id,
+                                target,
+                                candidates: res.candidates_with_rects,
+                                chosen_uid: res.chosen_uid,
+                                reasoning: res.reasoning,
+                                screenshot_path: res.screenshot_path,
+                                screenshot_base64: res.screenshot_base64,
+                            });
+                            continue;
+                        }
+                        Err(disambig_err) => {
+                            let msg = format!("Disambiguation failed: {}", disambig_err);
+                            self.emit_error(format!("Node {} failed: {}", node_name, msg));
+                            if let Some(run) = node_run {
+                                self.finalize_run(run, RunStatus::Failed);
+                            }
+                            self.emit(ExecutorEvent::NodeFailed(node_id, msg));
+                            return StepOutcome::Failed;
+                        }
+                    }
+                }
                 Err(e) => {
                     let msg = e.to_string();
                     self.emit_error(format!("Node {} failed: {}", node_name, msg));

--- a/crates/clickweave-engine/src/executor/run_loop.rs
+++ b/crates/clickweave-engine/src/executor/run_loop.rs
@@ -166,6 +166,7 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
                     // fresh start on each plain retry.
                     retry_ctx.write_tried_click_indices().clear();
                     retry_ctx.write_tried_cdp_uids().clear();
+                    retry_ctx.write_cdp_ambiguity_overrides().clear();
                     self.evict_caches_for_node(node_type);
                     retry_ctx.force_resolve = true;
                     self.record_event(
@@ -368,6 +369,7 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
                                     supervision_attempts = 0;
                                     ctx.write_tried_click_indices().clear();
                                     ctx.write_tried_cdp_uids().clear();
+                                    ctx.write_cdp_ambiguity_overrides().clear();
                                     ctx.supervision_hint = None;
                                     self.re_execute_preceding_click(node_id, node_type, mcp, ctx)
                                         .await;
@@ -443,6 +445,8 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
                                 candidates: res.candidates_with_rects,
                                 chosen_uid: res.chosen_uid,
                                 reasoning: res.reasoning,
+                                viewport_width: res.viewport_width,
+                                viewport_height: res.viewport_height,
                                 screenshot_path: res.screenshot_path,
                                 screenshot_base64: res.screenshot_base64,
                             });
@@ -585,6 +589,10 @@ impl<C: ChatBackend> WorkflowExecutor<C> {
             ctx.supervision_hint = None;
             ctx.write_tried_click_indices().clear();
             ctx.write_tried_cdp_uids().clear();
+            // Disambiguation overrides are per-node: a later node that happens
+            // to share a target label (e.g. "Save") must re-resolve against
+            // its own page rather than reuse an earlier node's chosen uid.
+            ctx.write_cdp_ambiguity_overrides().clear();
             self.log(format!(
                 "Executing node: {} ({})",
                 node_name,

--- a/crates/clickweave-engine/src/executor/tests/ambiguity.rs
+++ b/crates/clickweave-engine/src/executor/tests/ambiguity.rs
@@ -1,0 +1,267 @@
+//! Integration tests for the CDP ambiguity disambiguation path.
+//!
+//! These exercise `WorkflowExecutor::resolve_cdp_ambiguity` directly plus the
+//! retry_context override flow, avoiding the full run loop (which requires a
+//! live CDP connection).  The run-loop event emission is covered by the
+//! parse/unit tests inside `executor::ambiguity::tests`.
+
+use super::helpers::*;
+use crate::executor::error::{CdpCandidate, ExecutorError};
+use clickweave_core::storage::RunStorage;
+use clickweave_core::{ExecutionMode, TraceLevel, Workflow};
+use clickweave_mcp::{ToolCallResult, ToolContent};
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+/// Minimal 1x1 transparent PNG, base64-encoded. Small enough that
+/// `prepare_base64_image_for_vlm` can decode and pass it to the VLM stub.
+const TINY_PNG_BASE64: &str =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+
+fn screenshot_response() -> ToolCallResult {
+    ToolCallResult {
+        content: vec![ToolContent::Image {
+            data: TINY_PNG_BASE64.to_string(),
+            mime_type: "image/png".to_string(),
+        }],
+        is_error: None,
+    }
+}
+
+fn sample_candidates() -> Vec<CdpCandidate> {
+    vec![
+        CdpCandidate {
+            uid: "a1".to_string(),
+            snippet: "[uid=\"a1\"] button \"Save\"".to_string(),
+        },
+        CdpCandidate {
+            uid: "a2".to_string(),
+            snippet: "[uid=\"a2\"] button \"Save\"".to_string(),
+        },
+    ]
+}
+
+fn make_executor_with_vlm(
+    fast_responses: Vec<&str>,
+) -> crate::executor::WorkflowExecutor<ScriptedBackend> {
+    let (tx, _rx) = tokio::sync::mpsc::channel(256);
+    let workflow = Workflow::default();
+    let temp_dir = std::env::temp_dir().join(format!(
+        "clickweave_test_ambig_{}",
+        Uuid::new_v4().as_simple()
+    ));
+    let storage = RunStorage::new_app_data(&temp_dir, &workflow.name, workflow.id);
+    crate::executor::WorkflowExecutor::with_backends(
+        workflow,
+        ScriptedBackend::new(vec![]),
+        Some(ScriptedBackend::new(fast_responses)),
+        String::new(),
+        ExecutionMode::Run,
+        None,
+        tx,
+        storage,
+        CancellationToken::new(),
+    )
+}
+
+#[tokio::test]
+async fn resolve_cdp_ambiguity_returns_chosen_uid_and_rects_from_vlm() {
+    let exec = make_executor_with_vlm(vec![
+        r#"{"chosen_uid": "a2", "reasoning": "second Save is the primary toolbar action"}"#,
+    ]);
+
+    let mcp = StubToolProvider::new();
+    // capture_verification_screenshot -> take_screenshot (image)
+    mcp.push_response(screenshot_response());
+    // cdp_evaluate_script for rects
+    mcp.push_text_response(
+        r#"[{"x": 10.0, "y": 20.0, "width": 30.0, "height": 40.0}, {"x": 50.0, "y": 60.0, "width": 70.0, "height": 80.0}]"#,
+    );
+
+    let res = exec
+        .resolve_cdp_ambiguity(
+            Uuid::new_v4(),
+            "Click Save",
+            "Save",
+            sample_candidates(),
+            &mcp,
+            None,
+        )
+        .await
+        .expect("disambiguation should succeed");
+
+    assert_eq!(res.chosen_uid, "a2");
+    assert!(res.reasoning.to_lowercase().contains("toolbar"));
+    assert_eq!(res.candidates_with_rects.len(), 2);
+    let r0 = res.candidates_with_rects[0]
+        .rect
+        .as_ref()
+        .expect("first rect present");
+    assert_eq!(r0.x, 10.0);
+    assert_eq!(r0.width, 30.0);
+    let r1 = res.candidates_with_rects[1]
+        .rect
+        .as_ref()
+        .expect("second rect present");
+    assert_eq!(r1.y, 60.0);
+    // screenshot_path is a filename, not a full path — the UI resolves it
+    // relative to the node's artifacts dir.
+    assert!(res.screenshot_path.ends_with(".png"));
+    assert!(!res.screenshot_path.contains('/'));
+    // screenshot_base64 is the raw live image forwarded to the UI.
+    assert_eq!(res.screenshot_base64, TINY_PNG_BASE64);
+
+    // MCP was asked for a screenshot and a batched evaluate, in that order.
+    let calls = mcp.take_calls();
+    let names: Vec<&str> = calls.iter().map(|(n, _)| n.as_str()).collect();
+    assert_eq!(names, vec!["take_screenshot", "cdp_evaluate_script"]);
+}
+
+#[tokio::test]
+async fn resolve_cdp_ambiguity_propagates_vlm_parse_failure() {
+    let exec = make_executor_with_vlm(vec!["I can't decide, they all look the same."]);
+
+    let mcp = StubToolProvider::new();
+    mcp.push_response(screenshot_response());
+    mcp.push_text_response("[null, null]");
+
+    let err = exec
+        .resolve_cdp_ambiguity(
+            Uuid::new_v4(),
+            "Click Save",
+            "Save",
+            sample_candidates(),
+            &mcp,
+            None,
+        )
+        .await
+        .expect_err("unparsable VLM response must surface as an error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Disambiguation") && msg.contains("parse"),
+        "error should mention disambiguation+parse: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn resolve_cdp_ambiguity_rejects_unknown_uid_from_vlm() {
+    let exec = make_executor_with_vlm(vec![r#"{"chosen_uid": "zz", "reasoning": "fabricated"}"#]);
+
+    let mcp = StubToolProvider::new();
+    mcp.push_response(screenshot_response());
+    mcp.push_text_response("[null, null]");
+
+    let err = exec
+        .resolve_cdp_ambiguity(
+            Uuid::new_v4(),
+            "Click Save",
+            "Save",
+            sample_candidates(),
+            &mcp,
+            None,
+        )
+        .await
+        .expect_err("unknown chosen_uid must fail");
+    assert!(matches!(err, ExecutorError::Cdp(_)));
+    assert!(err.to_string().contains("unknown uid"));
+}
+
+#[tokio::test]
+async fn resolve_cdp_ambiguity_surfaces_screenshot_failure() {
+    let exec = make_executor_with_vlm(vec![]);
+
+    let mcp = StubToolProvider::new();
+    // take_screenshot returns is_error: Some(true) three times (retry loop).
+    for _ in 0..6 {
+        mcp.push_response(ToolCallResult {
+            content: vec![ToolContent::Text {
+                text: "screenshot denied".to_string(),
+            }],
+            is_error: Some(true),
+        });
+    }
+
+    let err = exec
+        .resolve_cdp_ambiguity(
+            Uuid::new_v4(),
+            "Click Save",
+            "Save",
+            sample_candidates(),
+            &mcp,
+            None,
+        )
+        .await
+        .expect_err("screenshot failure must bubble up");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("screenshot") || msg.contains("Disambiguation"),
+        "error message should mention screenshot or disambiguation: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn resolve_cdp_element_uid_short_circuits_on_override() {
+    // The override map should be consulted before any MCP round-trip. This
+    // guards the retry path: once the agent has picked a uid, the resolver
+    // must not re-take a snapshot (which would surface the same ambiguity).
+    use crate::executor::retry_context::RetryContext;
+
+    let exec = make_test_executor();
+    let ctx = RetryContext::new();
+    ctx.write_cdp_ambiguity_overrides()
+        .insert("Save".to_string(), "a2".to_string());
+
+    let mcp = StubToolProvider::new();
+    let uid = exec
+        .resolve_cdp_element_uid_with_overrides("Save", &mcp, Some(&ctx))
+        .await
+        .expect("override must short-circuit");
+    assert_eq!(uid, "a2");
+
+    // No MCP calls: no snapshot, no evaluate, nothing.
+    assert!(mcp.take_calls().is_empty());
+}
+
+#[tokio::test]
+async fn resolve_cdp_ambiguity_persists_artifacts_when_trace_enabled() {
+    let exec = make_executor_with_vlm(vec![
+        r#"{"chosen_uid": "a1", "reasoning": "first and only visible"}"#,
+    ]);
+
+    let mcp = StubToolProvider::new();
+    mcp.push_response(screenshot_response());
+    mcp.push_text_response("[null, null]");
+
+    // Create a NodeRun so the artifact-persistence branch fires.
+    let mut storage = RunStorage::new_app_data(
+        &std::env::temp_dir().join(format!(
+            "clickweave_test_ambig_art_{}",
+            Uuid::new_v4().as_simple()
+        )),
+        "Test",
+        Uuid::new_v4(),
+    );
+    storage.begin_execution().expect("begin");
+    let mut run = storage
+        .create_run(Uuid::new_v4(), "Click Save", TraceLevel::Minimal)
+        .expect("create run");
+
+    let res = exec
+        .resolve_cdp_ambiguity(
+            Uuid::new_v4(),
+            "Click Save",
+            "Save",
+            sample_candidates(),
+            &mcp,
+            Some(&mut run),
+        )
+        .await
+        .expect("disambiguation should succeed");
+
+    assert!(res.screenshot_path.ends_with(".png"));
+    // NodeRun should have picked up at least the screenshot artifact via
+    // save_artifact (executor's storage is separate from the test helper
+    // storage so the artifact files live under the executor's storage —
+    // this assertion verifies the path wiring rather than the files).
+    assert_eq!(res.candidates_with_rects.len(), 2);
+}

--- a/crates/clickweave-engine/src/executor/tests/ambiguity.rs
+++ b/crates/clickweave-engine/src/executor/tests/ambiguity.rs
@@ -79,14 +79,7 @@ async fn resolve_cdp_ambiguity_returns_chosen_uid_and_rects_from_vlm() {
     );
 
     let res = exec
-        .resolve_cdp_ambiguity(
-            Uuid::new_v4(),
-            "Click Save",
-            "Save",
-            sample_candidates(),
-            &mcp,
-            None,
-        )
+        .resolve_cdp_ambiguity("Click Save", "Save", sample_candidates(), &mcp, None)
         .await
         .expect("disambiguation should succeed");
 
@@ -126,14 +119,7 @@ async fn resolve_cdp_ambiguity_propagates_vlm_parse_failure() {
     mcp.push_text_response("[null, null]");
 
     let err = exec
-        .resolve_cdp_ambiguity(
-            Uuid::new_v4(),
-            "Click Save",
-            "Save",
-            sample_candidates(),
-            &mcp,
-            None,
-        )
+        .resolve_cdp_ambiguity("Click Save", "Save", sample_candidates(), &mcp, None)
         .await
         .expect_err("unparsable VLM response must surface as an error");
     let msg = err.to_string();
@@ -152,14 +138,7 @@ async fn resolve_cdp_ambiguity_rejects_unknown_uid_from_vlm() {
     mcp.push_text_response("[null, null]");
 
     let err = exec
-        .resolve_cdp_ambiguity(
-            Uuid::new_v4(),
-            "Click Save",
-            "Save",
-            sample_candidates(),
-            &mcp,
-            None,
-        )
+        .resolve_cdp_ambiguity("Click Save", "Save", sample_candidates(), &mcp, None)
         .await
         .expect_err("unknown chosen_uid must fail");
     assert!(matches!(err, ExecutorError::Cdp(_)));
@@ -182,14 +161,7 @@ async fn resolve_cdp_ambiguity_surfaces_screenshot_failure() {
     }
 
     let err = exec
-        .resolve_cdp_ambiguity(
-            Uuid::new_v4(),
-            "Click Save",
-            "Save",
-            sample_candidates(),
-            &mcp,
-            None,
-        )
+        .resolve_cdp_ambiguity("Click Save", "Save", sample_candidates(), &mcp, None)
         .await
         .expect_err("screenshot failure must bubble up");
     let msg = err.to_string();
@@ -248,7 +220,6 @@ async fn resolve_cdp_ambiguity_persists_artifacts_when_trace_enabled() {
 
     let res = exec
         .resolve_cdp_ambiguity(
-            Uuid::new_v4(),
             "Click Save",
             "Save",
             sample_candidates(),

--- a/crates/clickweave-engine/src/executor/tests/ambiguity.rs
+++ b/crates/clickweave-engine/src/executor/tests/ambiguity.rs
@@ -73,9 +73,11 @@ async fn resolve_cdp_ambiguity_returns_chosen_uid_and_rects_from_vlm() {
     let mcp = StubToolProvider::new();
     // capture_verification_screenshot -> take_screenshot (image)
     mcp.push_response(screenshot_response());
-    // cdp_evaluate_script for rects
+    // cdp_evaluate_script now returns a {viewport, rects} envelope.
     mcp.push_text_response(
-        r#"[{"x": 10.0, "y": 20.0, "width": 30.0, "height": 40.0}, {"x": 50.0, "y": 60.0, "width": 70.0, "height": 80.0}]"#,
+        r#"{"viewport": {"width": 1280.0, "height": 720.0},
+             "rects": [{"x": 10.0, "y": 20.0, "width": 30.0, "height": 40.0},
+                       {"x": 50.0, "y": 60.0, "width": 70.0, "height": 80.0}]}"#,
     );
 
     let res = exec
@@ -97,6 +99,8 @@ async fn resolve_cdp_ambiguity_returns_chosen_uid_and_rects_from_vlm() {
         .as_ref()
         .expect("second rect present");
     assert_eq!(r1.y, 60.0);
+    assert_eq!(res.viewport_width, 1280.0);
+    assert_eq!(res.viewport_height, 720.0);
     // screenshot_path is a filename, not a full path — the UI resolves it
     // relative to the node's artifacts dir.
     assert!(res.screenshot_path.ends_with(".png"));

--- a/crates/clickweave-engine/src/executor/tests/cdp.rs
+++ b/crates/clickweave-engine/src/executor/tests/cdp.rs
@@ -130,6 +130,27 @@ async fn resolve_cdp_element_uid_surfaces_ambiguous_candidates() {
         .await
         .expect_err("ambiguous match must fail loudly");
 
+    // Display must expose uids and target but not the raw snapshot snippets —
+    // those are only reachable through the structured variant fields, so that
+    // always-on log/UI surfaces stay free of live page DOM text.
+    let display = err.to_string();
+    assert!(
+        display.contains("Save"),
+        "display should mention target: {display}"
+    );
+    assert!(
+        display.contains("a1"),
+        "display should list uids: {display}"
+    );
+    assert!(
+        !display.contains("button"),
+        "display must not leak snippet tokens: {display}"
+    );
+    assert!(
+        !display.contains("[uid="),
+        "display must not leak snippet tokens: {display}"
+    );
+
     let ExecutorError::CdpAmbiguousTarget { target, candidates } = err else {
         panic!("expected CdpAmbiguousTarget, got: {err:?}");
     };

--- a/crates/clickweave-engine/src/executor/tests/cdp.rs
+++ b/crates/clickweave-engine/src/executor/tests/cdp.rs
@@ -79,6 +79,81 @@ async fn resolve_cdp_target_uid_resolves_intent_via_snapshot() {
 }
 
 #[tokio::test]
+async fn resolve_cdp_element_uid_succeeds_with_single_match() {
+    let exec = make_test_executor();
+    let mcp = StubToolProvider::new();
+    // cdp_list_pages (health check) then cdp_take_snapshot with exactly one match.
+    mcp.push_text_response("1: https://example.com [selected]");
+    mcp.push_text_response("[uid=\"a5\"] button \"Submit\"");
+
+    let uid = exec
+        .resolve_cdp_element_uid("Submit", &mcp)
+        .await
+        .expect("single match should resolve");
+    assert_eq!(uid, "a5");
+}
+
+#[tokio::test]
+async fn resolve_cdp_element_uid_reports_zero_matches() {
+    let exec = make_test_executor();
+    let mcp = StubToolProvider::new();
+    // Health check + three snapshot attempts that never mention the target.
+    mcp.push_text_response("1: https://example.com [selected]");
+    for _ in 0..3 {
+        mcp.push_text_response("[uid=\"a1\"] button \"Cancel\"");
+    }
+
+    let err = exec
+        .resolve_cdp_element_uid("Submit", &mcp)
+        .await
+        .expect_err("missing element must fail");
+    assert!(matches!(err, ExecutorError::Cdp(_)));
+    assert!(err.to_string().contains("No matching element"));
+}
+
+#[tokio::test]
+async fn resolve_cdp_element_uid_surfaces_ambiguous_candidates() {
+    use crate::executor::CdpCandidate;
+
+    let exec = make_test_executor();
+    let mcp = StubToolProvider::new();
+    // Health check + a snapshot with three buttons labelled "Save".
+    mcp.push_text_response("1: https://example.com [selected]");
+    mcp.push_text_response(concat!(
+        "[uid=\"a1\"] button \"Save\"\n",
+        "[uid=\"a2\"] button \"Save\"\n",
+        "[uid=\"a3\"] button \"Save\"\n",
+    ));
+
+    let err = exec
+        .resolve_cdp_element_uid("Save", &mcp)
+        .await
+        .expect_err("ambiguous match must fail loudly");
+
+    let ExecutorError::CdpAmbiguousTarget { target, candidates } = err else {
+        panic!("expected CdpAmbiguousTarget, got: {err:?}");
+    };
+    assert_eq!(target, "Save");
+    assert_eq!(
+        candidates,
+        vec![
+            CdpCandidate {
+                uid: "a1".to_string(),
+                snippet: "[uid=\"a1\"] button \"Save\"".to_string(),
+            },
+            CdpCandidate {
+                uid: "a2".to_string(),
+                snippet: "[uid=\"a2\"] button \"Save\"".to_string(),
+            },
+            CdpCandidate {
+                uid: "a3".to_string(),
+                snippet: "[uid=\"a3\"] button \"Save\"".to_string(),
+            },
+        ]
+    );
+}
+
+#[tokio::test]
 async fn execute_cdp_action_returns_resolver_error_when_target_missing() {
     // The deterministic executor no longer carries a silent native-click
     // fallback for elements absent from the CDP accessibility tree — the

--- a/crates/clickweave-engine/src/executor/tests/cdp.rs
+++ b/crates/clickweave-engine/src/executor/tests/cdp.rs
@@ -139,9 +139,15 @@ async fn resolve_cdp_element_uid_surfaces_ambiguous_candidates() {
         "display should mention target: {display}"
     );
     assert!(
-        display.contains("a1"),
-        "display should list uids: {display}"
+        display.contains("3 candidates"),
+        "display should mention candidate count: {display}"
     );
+    for uid in ["a1", "a2", "a3"] {
+        assert!(
+            display.contains(uid),
+            "display should list uid {uid}: {display}"
+        );
+    }
     assert!(
         !display.contains("button"),
         "display must not leak snippet tokens: {display}"

--- a/crates/clickweave-engine/src/executor/tests/mod.rs
+++ b/crates/clickweave-engine/src/executor/tests/mod.rs
@@ -1,3 +1,4 @@
+mod ambiguity;
 mod cache;
 mod cdp;
 mod focus_refresh;

--- a/src-tauri/src/commands/executor.rs
+++ b/src-tauri/src/commands/executor.rs
@@ -179,6 +179,38 @@ pub async fn run_workflow(app: tauri::AppHandle, request: RunRequest) -> Result<
                         screenshot,
                     },
                 ),
+                ExecutorEvent::AmbiguityResolved {
+                    node_id,
+                    target,
+                    candidates,
+                    chosen_uid,
+                    reasoning,
+                    screenshot_path,
+                    screenshot_base64,
+                } => emit_handle.emit(
+                    "executor://ambiguity_resolved",
+                    AmbiguityResolvedPayload {
+                        node_id: node_id.to_string(),
+                        target,
+                        candidates: candidates
+                            .into_iter()
+                            .map(|c| CandidateViewPayload {
+                                uid: c.uid,
+                                snippet: c.snippet,
+                                rect: c.rect.map(|r| CandidateRectPayload {
+                                    x: r.x,
+                                    y: r.y,
+                                    width: r.width,
+                                    height: r.height,
+                                }),
+                            })
+                            .collect(),
+                        chosen_uid,
+                        reasoning,
+                        screenshot_path,
+                        screenshot_base64,
+                    },
+                ),
                 ExecutorEvent::NodeCancelled(id) => emit_handle.emit(
                     "executor://node_cancelled",
                     NodePayload {

--- a/src-tauri/src/commands/executor.rs
+++ b/src-tauri/src/commands/executor.rs
@@ -185,6 +185,8 @@ pub async fn run_workflow(app: tauri::AppHandle, request: RunRequest) -> Result<
                     candidates,
                     chosen_uid,
                     reasoning,
+                    viewport_width,
+                    viewport_height,
                     screenshot_path,
                     screenshot_base64,
                 } => emit_handle.emit(
@@ -207,6 +209,8 @@ pub async fn run_workflow(app: tauri::AppHandle, request: RunRequest) -> Result<
                             .collect(),
                         chosen_uid,
                         reasoning,
+                        viewport_width,
+                        viewport_height,
                         screenshot_path,
                         screenshot_base64,
                     },

--- a/src-tauri/src/commands/types.rs
+++ b/src-tauri/src/commands/types.rs
@@ -155,6 +155,34 @@ pub struct NodeErrorPayload {
 }
 
 #[derive(Debug, Clone, Serialize)]
+pub struct CandidateRectPayload {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CandidateViewPayload {
+    pub uid: String,
+    pub snippet: String,
+    pub rect: Option<CandidateRectPayload>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AmbiguityResolvedPayload {
+    pub node_id: String,
+    pub target: String,
+    pub candidates: Vec<CandidateViewPayload>,
+    pub chosen_uid: String,
+    pub reasoning: String,
+    /// Screenshot filename relative to the node's `artifacts/` directory.
+    pub screenshot_path: String,
+    /// Base64-encoded PNG of the screenshot taken when the agent decided.
+    pub screenshot_base64: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct SupervisionPassedPayload {
     pub node_id: String,
     pub node_name: String,

--- a/src-tauri/src/commands/types.rs
+++ b/src-tauri/src/commands/types.rs
@@ -176,6 +176,8 @@ pub struct AmbiguityResolvedPayload {
     pub candidates: Vec<CandidateViewPayload>,
     pub chosen_uid: String,
     pub reasoning: String,
+    pub viewport_width: f64,
+    pub viewport_height: f64,
     /// Screenshot filename relative to the node's `artifacts/` directory.
     pub screenshot_path: String,
     /// Base64-encoded PNG of the screenshot taken when the agent decided.

--- a/ui/src/components/AmbiguityResolution.test.tsx
+++ b/ui/src/components/AmbiguityResolution.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { AmbiguityResolution } from "../store/slices/agentSlice";
+import { AmbiguityResolutionCard } from "./AmbiguityResolutionCard";
+import { AmbiguityResolutionModal } from "./AmbiguityResolutionModal";
+
+// A tiny 1x1 transparent PNG, base64-encoded.
+const TINY_PNG =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+
+function makeResolution(
+  overrides: Partial<AmbiguityResolution> = {},
+): AmbiguityResolution {
+  return {
+    id: "res-1",
+    nodeId: "node-1",
+    target: "Save",
+    chosenUid: "a2",
+    reasoning: "Second Save is the primary toolbar action.",
+    screenshotPath: "ambiguity_abc.png",
+    screenshotBase64: TINY_PNG,
+    createdAt: 1234,
+    candidates: [
+      {
+        uid: "a1",
+        snippet: '[uid="a1"] button "Save"',
+        rect: { x: 10, y: 20, width: 30, height: 40 },
+      },
+      {
+        uid: "a2",
+        snippet: '[uid="a2"] button "Save"',
+        rect: { x: 100, y: 200, width: 30, height: 40 },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("AmbiguityResolutionCard", () => {
+  it("shows the target and chosen uid", () => {
+    const onOpen = vi.fn();
+    render(
+      <AmbiguityResolutionCard resolution={makeResolution()} onOpen={onOpen} />,
+    );
+
+    expect(screen.getByText(/Ambiguity resolved/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Save/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText(/a2/)).toBeInTheDocument();
+  });
+
+  it("invokes onOpen when clicked", () => {
+    const onOpen = vi.fn();
+    render(
+      <AmbiguityResolutionCard resolution={makeResolution()} onOpen={onOpen} />,
+    );
+
+    fireEvent.click(screen.getByTestId("ambiguity-resolution-card"));
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("truncates long reasoning to a preview", () => {
+    const reasoning = "x".repeat(300);
+    const onOpen = vi.fn();
+    render(
+      <AmbiguityResolutionCard
+        resolution={makeResolution({ reasoning })}
+        onOpen={onOpen}
+      />,
+    );
+
+    // The preview must not contain all 300 characters; find text ending with ellipsis.
+    const card = screen.getByTestId("ambiguity-resolution-card");
+    expect(card.textContent).toContain("\u2026");
+    expect((card.textContent ?? "").length).toBeLessThan(300);
+  });
+});
+
+describe("AmbiguityResolutionModal", () => {
+  beforeEach(() => {
+    // jsdom lacks ResizeObserver — the modal reads it in a layout effect.
+    if (typeof globalThis.ResizeObserver === "undefined") {
+      class StubResizeObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      }
+      // @ts-expect-error jsdom-only shim
+      globalThis.ResizeObserver = StubResizeObserver;
+    }
+  });
+
+  it("renders the screenshot and all candidate uids", () => {
+    const onClose = vi.fn();
+    render(
+      <AmbiguityResolutionModal
+        resolution={makeResolution()}
+        onClose={onClose}
+      />,
+    );
+
+    // Image is present and has the screenshot data uri as src.
+    const img = screen.getByRole("img", {
+      name: /Screenshot with candidate overlays/i,
+    }) as HTMLImageElement;
+    expect(img.src).toContain("data:image/png;base64,");
+    expect(img.src).toContain(TINY_PNG);
+
+    // Each candidate uid appears in the candidate list.
+    // Two uids, appearing once in the list and possibly once in title.
+    expect(screen.getAllByText(/uid=a1/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/uid=a2/).length).toBeGreaterThanOrEqual(1);
+    // Chosen candidate carries a "picked" badge (the header also says
+    // "picked" so we assert at-least-one occurrence).
+    expect(screen.getAllByText(/picked/i).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("has a canvas overlay that draws N rects for N candidates", () => {
+    const onClose = vi.fn();
+    const resolution = makeResolution();
+    const { container } = render(
+      <AmbiguityResolutionModal resolution={resolution} onClose={onClose} />,
+    );
+
+    // Trigger the image's load handler so the layout-effect runs.
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    Object.defineProperty(img, "naturalWidth", {
+      configurable: true,
+      value: 200,
+    });
+    Object.defineProperty(img, "naturalHeight", {
+      configurable: true,
+      value: 200,
+    });
+    fireEvent.load(img!);
+
+    const canvas = container.querySelector("canvas");
+    expect(canvas).not.toBeNull();
+    // We can't reliably inspect canvas drawing in jsdom, but we can verify
+    // the canvas element is present and aria-hidden.
+    expect(canvas!.getAttribute("aria-hidden")).toBe("true");
+    // The list of candidates renders exactly one <li> per candidate.
+    const items = container.querySelectorAll("ul > li");
+    expect(items.length).toBe(resolution.candidates.length);
+  });
+
+  it("calls onClose when the close button is clicked", () => {
+    const onClose = vi.fn();
+    render(
+      <AmbiguityResolutionModal
+        resolution={makeResolution()}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /close/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when Escape is pressed", () => {
+    const onClose = vi.fn();
+    render(
+      <AmbiguityResolutionModal
+        resolution={makeResolution()}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/components/AmbiguityResolution.test.tsx
+++ b/ui/src/components/AmbiguityResolution.test.tsx
@@ -17,6 +17,8 @@ function makeResolution(
     target: "Save",
     chosenUid: "a2",
     reasoning: "Second Save is the primary toolbar action.",
+    viewportWidth: 1280,
+    viewportHeight: 720,
     screenshotPath: "ambiguity_abc.png",
     screenshotBase64: TINY_PNG,
     createdAt: 1234,

--- a/ui/src/components/AmbiguityResolutionCard.tsx
+++ b/ui/src/components/AmbiguityResolutionCard.tsx
@@ -1,0 +1,56 @@
+import type { AmbiguityResolution } from "../store/slices/agentSlice";
+
+interface Props {
+  resolution: AmbiguityResolution;
+  onOpen: () => void;
+}
+
+const REASONING_PREVIEW_CHARS = 60;
+
+/**
+ * Persistent agent-panel card rendered when the engine resolves an ambiguous
+ * CDP target. Clicking opens the full modal with the screenshot and every
+ * candidate's bounding rect overlaid.
+ */
+export function AmbiguityResolutionCard({ resolution, onOpen }: Props) {
+  const preview =
+    resolution.reasoning.length > REASONING_PREVIEW_CHARS
+      ? `${resolution.reasoning.slice(0, REASONING_PREVIEW_CHARS)}\u2026`
+      : resolution.reasoning;
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      data-testid="ambiguity-resolution-card"
+      className="group mx-3 mb-2 block w-[calc(100%-1.5rem)] rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-2.5 text-left transition-colors hover:border-emerald-400/60 hover:bg-emerald-500/15 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
+      aria-label={`Open ambiguity resolution for ${resolution.target}`}
+    >
+      <div className="flex items-center gap-1.5">
+        <span
+          aria-hidden="true"
+          className="inline-block h-2 w-2 rounded-full bg-emerald-400"
+        />
+        <span className="text-[11px] font-medium uppercase tracking-wide text-emerald-300">
+          Ambiguity resolved
+        </span>
+        <span className="ml-auto text-[10px] text-[var(--text-muted)] group-hover:text-[var(--text-secondary)]">
+          open &rsaquo;
+        </span>
+      </div>
+      <p className="mt-1 text-xs text-[var(--text-primary)]">
+        Resolved &ldquo;
+        <span className="font-medium">{resolution.target}</span>
+        &rdquo; &mdash; picked uid=
+        <span className="font-mono text-emerald-300">
+          {resolution.chosenUid}
+        </span>
+      </p>
+      {preview && (
+        <p className="mt-0.5 line-clamp-2 text-[11px] leading-relaxed text-[var(--text-muted)]">
+          {preview}
+        </p>
+      )}
+    </button>
+  );
+}

--- a/ui/src/components/AmbiguityResolutionModal.tsx
+++ b/ui/src/components/AmbiguityResolutionModal.tsx
@@ -1,0 +1,227 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import type {
+  AmbiguityCandidateView,
+  AmbiguityResolution,
+} from "../store/slices/agentSlice";
+import { Modal } from "./Modal";
+
+interface Props {
+  resolution: AmbiguityResolution;
+  onClose: () => void;
+}
+
+const NON_CHOSEN_STROKE = "#94a3b8"; // slate-400
+const CHOSEN_STROKE = "#10b981"; // emerald-500
+const CHOSEN_FILL = "rgba(16, 185, 129, 0.15)";
+
+/**
+ * Modal showing the screenshot taken at agent-decision time with every
+ * candidate's rect overlaid. The chosen candidate gets a thicker, accented
+ * outline plus a subtle fill tint so it's immediately obvious which one the
+ * agent committed to.
+ *
+ * Rects come from the CDP viewport (CSS pixels). The captured image may be at
+ * a different natural resolution than the viewport (device-pixel ratio), so
+ * we scale by the ratio between the rendered image size and the natural image
+ * size.
+ */
+export function AmbiguityResolutionModal({ resolution, onClose }: Props) {
+  const imageRef = useRef<HTMLImageElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const [imageLoaded, setImageLoaded] = useState(false);
+
+  useEffect(() => {
+    // Focus the dialog on mount so Esc + tab trapping work.
+    dialogRef.current?.focus();
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!imageLoaded) return;
+    const img = imageRef.current;
+    const canvas = canvasRef.current;
+    if (!img || !canvas) return;
+
+    const draw = () => {
+      const rect = img.getBoundingClientRect();
+      const dpr = window.devicePixelRatio || 1;
+      canvas.width = Math.max(1, Math.floor(rect.width * dpr));
+      canvas.height = Math.max(1, Math.floor(rect.height * dpr));
+      canvas.style.width = `${rect.width}px`;
+      canvas.style.height = `${rect.height}px`;
+
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return;
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
+      ctx.scale(dpr, dpr);
+      ctx.clearRect(0, 0, rect.width, rect.height);
+
+      // Scale CDP-viewport coordinates (naturalWidth/Height) to the rendered
+      // image size. If naturalWidth is 0 (still decoding), skip.
+      if (img.naturalWidth === 0 || img.naturalHeight === 0) return;
+      const sx = rect.width / img.naturalWidth;
+      const sy = rect.height / img.naturalHeight;
+
+      const drawRect = (c: AmbiguityCandidateView, isChosen: boolean) => {
+        if (!c.rect) return;
+        const x = c.rect.x * sx;
+        const y = c.rect.y * sy;
+        const w = c.rect.width * sx;
+        const h = c.rect.height * sy;
+
+        if (isChosen) {
+          ctx.fillStyle = CHOSEN_FILL;
+          ctx.fillRect(x, y, w, h);
+          ctx.strokeStyle = CHOSEN_STROKE;
+          ctx.lineWidth = 3;
+        } else {
+          ctx.strokeStyle = NON_CHOSEN_STROKE;
+          ctx.lineWidth = 2;
+        }
+        ctx.strokeRect(x, y, w, h);
+
+        // Label with uid (small text on a dark background for readability).
+        const label = `uid=${c.uid}`;
+        ctx.font = "11px ui-sans-serif, system-ui, sans-serif";
+        const metrics = ctx.measureText(label);
+        const padding = 4;
+        const labelWidth = metrics.width + padding * 2;
+        const labelHeight = 16;
+        ctx.fillStyle = isChosen
+          ? CHOSEN_STROKE
+          : "rgba(15, 23, 42, 0.85)";
+        ctx.fillRect(x, Math.max(0, y - labelHeight), labelWidth, labelHeight);
+        ctx.fillStyle = "#ffffff";
+        ctx.fillText(label, x + padding, Math.max(11, y - 4));
+      };
+
+      // Draw non-chosen first so the chosen accentuation sits on top.
+      for (const c of resolution.candidates) {
+        if (c.uid !== resolution.chosenUid) drawRect(c, false);
+      }
+      for (const c of resolution.candidates) {
+        if (c.uid === resolution.chosenUid) drawRect(c, true);
+      }
+    };
+
+    draw();
+    const ro = new ResizeObserver(() => draw());
+    ro.observe(img);
+    window.addEventListener("resize", draw);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener("resize", draw);
+    };
+  }, [imageLoaded, resolution]);
+
+  return (
+    <Modal open onClose={onClose} className="w-[min(960px,95vw)] max-h-[92vh]">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="ambiguity-modal-title"
+        ref={dialogRef}
+        tabIndex={-1}
+        className="flex max-h-[92vh] flex-col overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--bg-panel)] shadow-2xl outline-none"
+      >
+        <div className="flex items-start justify-between gap-3 border-b border-[var(--border)] px-5 py-3">
+          <div>
+            <h3
+              id="ambiguity-modal-title"
+              className="text-sm font-medium text-[var(--text-primary)]"
+            >
+              Resolved ambiguity on &ldquo;{resolution.target}&rdquo;
+            </h3>
+            <p className="mt-0.5 text-[11px] text-[var(--text-muted)]">
+              {resolution.candidates.length} candidates matched — agent picked{" "}
+              <span className="font-mono text-emerald-400">
+                uid={resolution.chosenUid}
+              </span>
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded px-2 py-1 text-sm text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+          >
+            &times;
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-5 py-4">
+          <section className="mb-4">
+            <h4 className="mb-1 text-[11px] font-medium uppercase tracking-wide text-[var(--text-muted)]">
+              Reasoning
+            </h4>
+            <p className="rounded bg-[var(--bg-dark)] px-3 py-2 text-xs leading-relaxed text-[var(--text-secondary)]">
+              {resolution.reasoning}
+            </p>
+          </section>
+
+          <section className="mb-4">
+            <h4 className="mb-1 text-[11px] font-medium uppercase tracking-wide text-[var(--text-muted)]">
+              Screenshot at decision time
+            </h4>
+            <div className="relative inline-block max-w-full rounded border border-[var(--border)] bg-black">
+              <img
+                ref={imageRef}
+                src={`data:image/png;base64,${resolution.screenshotBase64}`}
+                alt="Screenshot with candidate overlays"
+                className="block max-h-[60vh] max-w-full"
+                onLoad={() => setImageLoaded(true)}
+              />
+              <canvas
+                ref={canvasRef}
+                className="pointer-events-none absolute left-0 top-0"
+                aria-hidden="true"
+              />
+            </div>
+          </section>
+
+          <section>
+            <h4 className="mb-1 text-[11px] font-medium uppercase tracking-wide text-[var(--text-muted)]">
+              Candidates
+            </h4>
+            <ul className="space-y-1 text-xs">
+              {resolution.candidates.map((c) => {
+                const isChosen = c.uid === resolution.chosenUid;
+                return (
+                  <li
+                    key={c.uid}
+                    className={`flex items-start gap-2 rounded px-2 py-1.5 ${
+                      isChosen
+                        ? "bg-emerald-500/10 text-[var(--text-primary)]"
+                        : "bg-[var(--bg-dark)] text-[var(--text-secondary)]"
+                    }`}
+                  >
+                    <span
+                      className={`mt-0.5 inline-block h-3 w-3 rounded-sm ${
+                        isChosen
+                          ? "bg-emerald-500"
+                          : "border border-slate-400 bg-transparent"
+                      }`}
+                      aria-hidden="true"
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="font-mono">
+                        uid={c.uid}
+                        {isChosen && (
+                          <span className="ml-2 rounded bg-emerald-500/20 px-1.5 text-[10px] font-medium text-emerald-300">
+                            picked
+                          </span>
+                        )}
+                      </div>
+                      <div className="truncate text-[11px] text-[var(--text-muted)]">
+                        {c.snippet}
+                      </div>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/ui/src/components/AmbiguityResolutionModal.tsx
+++ b/ui/src/components/AmbiguityResolutionModal.tsx
@@ -20,10 +20,17 @@ const CHOSEN_FILL = "rgba(16, 185, 129, 0.15)";
  * outline plus a subtle fill tint so it's immediately obvious which one the
  * agent committed to.
  *
- * Rects come from the CDP viewport (CSS pixels). The captured image may be at
- * a different natural resolution than the viewport (device-pixel ratio), so
- * we scale by the ratio between the rendered image size and the natural image
- * size.
+ * Rects come from the CDP viewport (CSS pixels, top-left is the viewport
+ * origin). The engine captures a whole-window screenshot that may include OS
+ * chrome (title bar, tab bar) above the viewport, so we need the viewport
+ * dimensions to compute:
+ *   - scale: imagePx per viewport CSS px (pick the axis that matches so we
+ *     don't stretch).
+ *   - offset: how many image pixels of chrome sit above the viewport —
+ *     approximated as `naturalHeight - viewportHeight*scale` on the vertical
+ *     axis and centered horizontally.
+ * When `viewportWidth`/`viewportHeight` are 0 (CDP evaluate failed), we fall
+ * back to the old full-image scaling so the overlay still shows something.
  */
 export function AmbiguityResolutionModal({ resolution, onClose }: Props) {
   const imageRef = useRef<HTMLImageElement>(null);
@@ -56,16 +63,33 @@ export function AmbiguityResolutionModal({ resolution, onClose }: Props) {
       ctx.scale(dpr, dpr);
       ctx.clearRect(0, 0, rect.width, rect.height);
 
-      // Scale CDP-viewport coordinates (naturalWidth/Height) to the rendered
-      // image size. If naturalWidth is 0 (still decoding), skip.
+      // Viewport → image mapping. Candidate rects are viewport-relative
+      // (CSS pixels). The screenshot may include OS chrome around the
+      // viewport, so scale by the viewport extent and offset by the chrome
+      // band. When viewport info is missing, assume the image IS the
+      // viewport (fallback).
       if (img.naturalWidth === 0 || img.naturalHeight === 0) return;
-      const sx = rect.width / img.naturalWidth;
-      const sy = rect.height / img.naturalHeight;
+      const { viewportWidth, viewportHeight } = resolution;
+      const hasViewport = viewportWidth > 0 && viewportHeight > 0;
+      const vpW = hasViewport ? viewportWidth : img.naturalWidth;
+      const vpH = hasViewport ? viewportHeight : img.naturalHeight;
+      const dispToImage = rect.width / img.naturalWidth;
+      const sx = (rect.width / vpW) * (vpW / img.naturalWidth);
+      const sy = (rect.height / vpH) * (vpH / img.naturalHeight);
+      // Chrome offset inside the image (image px): whatever's above/beside
+      // the viewport. Horizontal offset assumes chrome is roughly centered
+      // (true for most browser windows); vertical offset assumes chrome sits
+      // at the top (tab + title bars).
+      const chromeXImgPx = Math.max(0, img.naturalWidth - vpW) / 2;
+      const chromeYImgPx = Math.max(0, img.naturalHeight - vpH);
+      // Convert image-pixel offsets to rendered-pixel offsets.
+      const offsetX = chromeXImgPx * dispToImage;
+      const offsetY = chromeYImgPx * (rect.height / img.naturalHeight);
 
       const drawRect = (c: AmbiguityCandidateView, isChosen: boolean) => {
         if (!c.rect) return;
-        const x = c.rect.x * sx;
-        const y = c.rect.y * sy;
+        const x = c.rect.x * sx + offsetX;
+        const y = c.rect.y * sy + offsetY;
         const w = c.rect.width * sx;
         const h = c.rect.height * sy;
 

--- a/ui/src/components/AssistantPanel.tsx
+++ b/ui/src/components/AssistantPanel.tsx
@@ -2,6 +2,8 @@ import { useState, useRef, useEffect } from "react";
 import type { AssistantMessage } from "../store/slices/assistantSlice";
 import { useHorizontalResize } from "../hooks/useHorizontalResize";
 import { useStore } from "../store/useAppStore";
+import { AmbiguityResolutionCard } from "./AmbiguityResolutionCard";
+import { AmbiguityResolutionModal } from "./AmbiguityResolutionModal";
 
 interface AssistantPanelProps {
   open: boolean;
@@ -28,6 +30,12 @@ export function AssistantPanel({
   const stopAgent = useStore((s) => s.stopAgent);
   const approveAction = useStore((s) => s.approveAction);
   const rejectAction = useStore((s) => s.rejectAction);
+  const ambiguityResolutions = useStore((s) => s.ambiguityResolutions);
+  const activeAmbiguityId = useStore((s) => s.activeAmbiguityId);
+  const openAmbiguityModal = useStore((s) => s.openAmbiguityModal);
+  const closeAmbiguityModal = useStore((s) => s.closeAmbiguityModal);
+  const activeAmbiguity =
+    ambiguityResolutions.find((r) => r.id === activeAmbiguityId) ?? null;
   const agentRunning = agentStatus === "running";
 
   // Auto-scroll to bottom when messages change
@@ -63,6 +71,7 @@ export function AssistantPanel({
   const hasMessages = messages.length > 0;
 
   return (
+    <>
     <div className="relative flex h-full flex-col border-l border-[var(--border)] bg-[var(--bg-panel)]" style={{ width, minWidth: width }}>
       {/* Resize handle */}
       <div
@@ -133,6 +142,15 @@ export function AssistantPanel({
           {error}
         </div>
       )}
+
+      {/* Ambiguity resolution cards — newest first, persists across runs. */}
+      {ambiguityResolutions.map((r) => (
+        <AmbiguityResolutionCard
+          key={r.id}
+          resolution={r}
+          onOpen={() => openAmbiguityModal(r.id)}
+        />
+      ))}
 
       {/* Approval card */}
       {pendingApproval && (
@@ -217,6 +235,13 @@ export function AssistantPanel({
         )}
       </div>
     </div>
+    {activeAmbiguity && (
+      <AmbiguityResolutionModal
+        resolution={activeAmbiguity}
+        onClose={closeAmbiguityModal}
+      />
+    )}
+    </>
   );
 }
 

--- a/ui/src/hooks/events/useExecutorNodeEvents.ts
+++ b/ui/src/hooks/events/useExecutorNodeEvents.ts
@@ -2,6 +2,17 @@ import { useEffect } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { useStore } from "../../store/useAppStore";
 import type { NodeVerdict } from "../../store/slices/verdictSlice";
+import type { AmbiguityCandidateView } from "../../store/slices/agentSlice";
+
+interface AmbiguityResolvedPayload {
+  node_id: string;
+  target: string;
+  candidates: AmbiguityCandidateView[];
+  chosen_uid: string;
+  reasoning: string;
+  screenshot_path: string;
+  screenshot_base64: string;
+}
 
 /**
  * Subscribe to executor node lifecycle events:
@@ -47,6 +58,30 @@ export function useExecutorNodeEvents() {
       useStore.getState().setActiveNode(null);
       useStore.getState().pushLog(`Node failed: ${e.payload.node_id} - ${e.payload.error}`);
       useStore.getState().setLastRunStatus("failed");
+    }));
+    sub(listen<AmbiguityResolvedPayload>("executor://ambiguity_resolved", (e) => {
+      const p = e.payload;
+      const id = `${p.node_id}:${p.target}:${Date.now()}`;
+      useStore.getState().addAmbiguityResolution({
+        id,
+        nodeId: p.node_id,
+        target: p.target,
+        candidates: p.candidates.map((c) => ({
+          uid: c.uid,
+          snippet: c.snippet,
+          rect: c.rect ?? null,
+        })),
+        chosenUid: p.chosen_uid,
+        reasoning: p.reasoning,
+        screenshotPath: p.screenshot_path,
+        screenshotBase64: p.screenshot_base64,
+        createdAt: Date.now(),
+      });
+      useStore
+        .getState()
+        .pushLog(
+          `Resolved ambiguity on '${p.target}' — picked uid=${p.chosen_uid}`,
+        );
     }));
     sub(listen<NodeVerdict[]>("executor://checks_completed", (e) => {
       useStore.getState().setVerdicts(e.payload);

--- a/ui/src/hooks/events/useExecutorNodeEvents.ts
+++ b/ui/src/hooks/events/useExecutorNodeEvents.ts
@@ -10,6 +10,8 @@ interface AmbiguityResolvedPayload {
   candidates: AmbiguityCandidateView[];
   chosen_uid: string;
   reasoning: string;
+  viewport_width: number;
+  viewport_height: number;
   screenshot_path: string;
   screenshot_base64: string;
 }
@@ -73,6 +75,8 @@ export function useExecutorNodeEvents() {
         })),
         chosenUid: p.chosen_uid,
         reasoning: p.reasoning,
+        viewportWidth: p.viewport_width,
+        viewportHeight: p.viewport_height,
         screenshotPath: p.screenshot_path,
         screenshotBase64: p.screenshot_base64,
         createdAt: Date.now(),

--- a/ui/src/store/slices/agentSlice.test.ts
+++ b/ui/src/store/slices/agentSlice.test.ts
@@ -58,6 +58,63 @@ describe("agentSlice.startAgent", () => {
   });
 });
 
+describe("agentSlice ambiguity resolutions", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    useStore.getState().clearAmbiguityResolutions();
+    useStore.getState().resetAgent();
+  });
+
+  const sample = {
+    id: "res-1",
+    nodeId: "node-1",
+    target: "Save",
+    candidates: [
+      {
+        uid: "a1",
+        snippet: '[uid="a1"] button "Save"',
+        rect: { x: 1, y: 2, width: 3, height: 4 },
+      },
+    ],
+    chosenUid: "a1",
+    reasoning: "only visible candidate",
+    screenshotPath: "ambiguity_abc.png",
+    screenshotBase64: "aaaa",
+    createdAt: 1,
+  };
+
+  it("prepends new resolutions so the newest shows first", () => {
+    useStore.getState().addAmbiguityResolution(sample);
+    useStore
+      .getState()
+      .addAmbiguityResolution({ ...sample, id: "res-2", target: "Delete" });
+    const list = useStore.getState().ambiguityResolutions;
+    expect(list.map((r) => r.id)).toEqual(["res-2", "res-1"]);
+  });
+
+  it("open/close modal toggles activeAmbiguityId", () => {
+    useStore.getState().addAmbiguityResolution(sample);
+    useStore.getState().openAmbiguityModal("res-1");
+    expect(useStore.getState().activeAmbiguityId).toBe("res-1");
+    useStore.getState().closeAmbiguityModal();
+    expect(useStore.getState().activeAmbiguityId).toBeNull();
+  });
+
+  it("resetAgent keeps ambiguity history intact for cross-run inspection", () => {
+    useStore.getState().addAmbiguityResolution(sample);
+    useStore.getState().resetAgent();
+    expect(useStore.getState().ambiguityResolutions.length).toBe(1);
+  });
+
+  it("clearAmbiguityResolutions empties the list and closes the modal", () => {
+    useStore.getState().addAmbiguityResolution(sample);
+    useStore.getState().openAmbiguityModal("res-1");
+    useStore.getState().clearAmbiguityResolutions();
+    expect(useStore.getState().ambiguityResolutions).toEqual([]);
+    expect(useStore.getState().activeAmbiguityId).toBeNull();
+  });
+});
+
 describe("agentSlice approval actions", () => {
   beforeEach(() => {
     invokeMock.mockReset();

--- a/ui/src/store/slices/agentSlice.test.ts
+++ b/ui/src/store/slices/agentSlice.test.ts
@@ -78,6 +78,8 @@ describe("agentSlice ambiguity resolutions", () => {
     ],
     chosenUid: "a1",
     reasoning: "only visible candidate",
+    viewportWidth: 1280,
+    viewportHeight: 720,
     screenshotPath: "ambiguity_abc.png",
     screenshotBase64: "aaaa",
     createdAt: 1,

--- a/ui/src/store/slices/agentSlice.ts
+++ b/ui/src/store/slices/agentSlice.ts
@@ -21,6 +21,36 @@ export interface PendingApproval {
   description: string;
 }
 
+export interface CandidateRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface AmbiguityCandidateView {
+  uid: string;
+  snippet: string;
+  rect: CandidateRect | null;
+}
+
+export interface AmbiguityResolution {
+  /** Client-side id so the UI can key modals/cards without relying on
+   *  backend-supplied node_id (multiple resolutions can fire per node). */
+  id: string;
+  nodeId: string;
+  target: string;
+  candidates: AmbiguityCandidateView[];
+  chosenUid: string;
+  reasoning: string;
+  /** Path relative to the node's `artifacts/` directory. */
+  screenshotPath: string;
+  /** Base64-encoded PNG data. Populated from the live executor event. */
+  screenshotBase64: string;
+  /** Epoch ms at which the resolution was observed on the UI side. */
+  createdAt: number;
+}
+
 /**
  * Tauri rejects with a structured `CommandError { kind, message }` for
  * typed failures (e.g. `AlreadyRunning`), but tauri-specta can also
@@ -45,6 +75,12 @@ export interface AgentSlice {
   pendingApproval: PendingApproval | null;
   /** Generation ID for the active run — used to reject stale events. */
   agentRunId: string | null;
+  /** Ambiguity resolution records, newest first. Persists across agent
+   *  completion so the user can inspect past resolutions. */
+  ambiguityResolutions: AmbiguityResolution[];
+  /** Active modal target for the ambiguity inspector, keyed by
+   *  AmbiguityResolution.id. */
+  activeAmbiguityId: string | null;
   startAgent: (goal: string) => Promise<void>;
   stopAgent: () => Promise<void>;
   addAgentStep: (step: AgentStep) => void;
@@ -57,6 +93,10 @@ export interface AgentSlice {
   setAgentError: (error: string | null) => void;
   setAgentRunId: (runId: string) => void;
   resetAgent: () => void;
+  addAmbiguityResolution: (resolution: AmbiguityResolution) => void;
+  openAmbiguityModal: (id: string) => void;
+  closeAmbiguityModal: () => void;
+  clearAmbiguityResolutions: () => void;
 }
 
 export const createAgentSlice: StateCreator<StoreState, [], [], AgentSlice> = (
@@ -70,6 +110,8 @@ export const createAgentSlice: StateCreator<StoreState, [], [], AgentSlice> = (
   currentAgentStep: 0,
   pendingApproval: null,
   agentRunId: null,
+  ambiguityResolutions: [],
+  activeAmbiguityId: null,
 
   startAgent: async (goal) => {
     const { pushLog, agentConfig, projectPath, workflow } = get();
@@ -175,5 +217,20 @@ export const createAgentSlice: StateCreator<StoreState, [], [], AgentSlice> = (
       currentAgentStep: 0,
       pendingApproval: null,
       agentRunId: null,
+      // Ambiguity records are intentionally NOT cleared — they persist across
+      // runs so the user can still inspect past resolutions until they
+      // explicitly clear them or start a new project.
     }),
+
+  addAmbiguityResolution: (resolution) =>
+    set((s) => ({
+      ambiguityResolutions: [resolution, ...s.ambiguityResolutions],
+    })),
+
+  openAmbiguityModal: (id) => set({ activeAmbiguityId: id }),
+
+  closeAmbiguityModal: () => set({ activeAmbiguityId: null }),
+
+  clearAmbiguityResolutions: () =>
+    set({ ambiguityResolutions: [], activeAmbiguityId: null }),
 });

--- a/ui/src/store/slices/agentSlice.ts
+++ b/ui/src/store/slices/agentSlice.ts
@@ -43,6 +43,10 @@ export interface AmbiguityResolution {
   candidates: AmbiguityCandidateView[];
   chosenUid: string;
   reasoning: string;
+  /** Viewport dimensions (CSS pixels) at capture time — rects are relative
+   *  to this viewport, not to the full screenshot. `0` means unknown. */
+  viewportWidth: number;
+  viewportHeight: number;
   /** Path relative to the node's `artifacts/` directory. */
   screenshotPath: string;
   /** Base64-encoded PNG data. Populated from the live executor event. */

--- a/ui/src/store/slices/projectSlice.ts
+++ b/ui/src/store/slices/projectSlice.ts
@@ -47,6 +47,8 @@ export const createProjectSlice: StateCreator<StoreState, [], [], ProjectSlice> 
       messages: [],
     });
     get().clearHistory();
+    // Ambiguity resolutions are specific to the prior workflow's nodes.
+    get().clearAmbiguityResolutions();
 
     pushLog(`Opened: ${filePath}`);
   },
@@ -84,6 +86,7 @@ export const createProjectSlice: StateCreator<StoreState, [], [], ProjectSlice> 
       assistantError: null,
     });
     get().clearHistory();
+    get().clearAmbiguityResolutions();
     pushLog("New project created");
   },
 


### PR DESCRIPTION
## Summary

- `resolve_cdp_element_uid` previously took the first snapshot line whose label matched the target, producing silent wrong-element clicks when multiple elements matched. It now returns a new typed `ExecutorError::CdpAmbiguousTarget { target, candidates }` variant carrying every matched candidate (uid + snapshot snippet) so the ambiguity is observable instead of silently mispicked.
- Zero-match and single-match behaviour unchanged. Richer integration with the observe-act agent layer (structured event payloads, auto-disambiguation) is intentionally out of scope for this PR.
- `Display` for the new variant emits only the target, candidate count, and uids — full snippets stay on the structured fields so live-page DOM text never lands in always-on app/UI logs.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy -p clickweave-engine --all-targets -- -D warnings`
- [x] `cargo test -p clickweave-engine` (190 passed)
- [x] New unit tests for `collect_snapshot_candidates`: skips `StaticText`/`InlineTextBox`, case-insensitive match, returns every match on ambiguous input
- [x] New integration tests for `resolve_cdp_element_uid`: single match resolves, zero matches yields `ExecutorError::Cdp("No matching element ...")`, ambiguous match yields `CdpAmbiguousTarget` with the full candidate list and a redacted `Display` string