### PR TITLE
fix(ui): preserve agent run state across rejection and start races

### DIFF
--- a/ui/src/store/slices/agentSlice.test.ts
+++ b/ui/src/store/slices/agentSlice.test.ts
@@ -141,6 +141,49 @@ describe("agentSlice.startAgent", () => {
     const lastLog = useStore.getState().logs.at(-1);
     expect(lastLog).toContain("Agent start rejected");
   });
+
+  it("restores the prior run's terminal state when AlreadyRunning fires during backend cleanup", async () => {
+    // Backend cleanup is async: after a terminal event the handle can
+    // still be populated for a brief window, during which run_agent
+    // rejects with AlreadyRunning even though the UI has already left
+    // the "running" state.
+    useStore.getState().setAgentRunId("run-prior");
+    useStore.getState().setAgentStatus("complete");
+    useStore.getState().addAgentStep({
+      summary: "prior step",
+      toolName: "click",
+      toolArgs: null,
+      toolResult: "ok",
+      pageTransitioned: false,
+    });
+
+    invokeMock.mockRejectedValueOnce({
+      kind: "AlreadyRunning",
+      message: "Already running",
+    });
+
+    await useStore.getState().startAgent("retry goal");
+
+    const state = useStore.getState();
+    // Terminal run's history must be preserved — not converted to "error".
+    expect(state.agentStatus).toBe("complete");
+    expect(state.agentRunId).toBe("run-prior");
+    expect(state.agentSteps).toHaveLength(1);
+    expect(state.agentError).toBeNull();
+  });
+
+  it("restores the prior run's terminal state on string-serialized AlreadyRunning during cleanup", async () => {
+    useStore.getState().setAgentRunId("run-prior");
+    useStore.getState().setAgentStatus("stopped");
+
+    invokeMock.mockRejectedValueOnce("AlreadyRunning: Already running");
+
+    await useStore.getState().startAgent("retry goal");
+
+    const state = useStore.getState();
+    expect(state.agentStatus).toBe("stopped");
+    expect(state.agentRunId).toBe("run-prior");
+  });
 });
 
 describe("agentSlice approval actions", () => {

--- a/ui/src/store/slices/agentSlice.test.ts
+++ b/ui/src/store/slices/agentSlice.test.ts
@@ -81,13 +81,17 @@ describe("agentSlice.startAgent", () => {
     expect(state.pendingApproval).toBeNull();
   });
 
-  it("clears the previous agentRunId after a successful invoke so agent://started can install a fresh one", async () => {
-    useStore.getState().setAgentRunId("run-prior");
-    invokeMock.mockResolvedValueOnce(undefined);
+  it("does not overwrite an agentRunId installed by agent://started during invoke", async () => {
+    // Simulate the backend emitting agent://started (which calls
+    // setAgentRunId) *before* the invoke promise resolves — the listener
+    // races the continuation in useAgentEvents.
+    invokeMock.mockImplementationOnce(async () => {
+      useStore.getState().setAgentRunId("run-new");
+    });
 
     await useStore.getState().startAgent("fresh goal");
 
-    expect(useStore.getState().agentRunId).toBeNull();
+    expect(useStore.getState().agentRunId).toBe("run-new");
   });
 });
 

--- a/ui/src/store/slices/agentSlice.test.ts
+++ b/ui/src/store/slices/agentSlice.test.ts
@@ -93,6 +93,36 @@ describe("agentSlice.startAgent", () => {
 
     expect(useStore.getState().agentRunId).toBe("run-new");
   });
+
+  it("sets agentStatus to running before awaiting invoke on a fresh start", async () => {
+    // Early terminal events (e.g. agent://error from a fast MCP-spawn
+    // failure) can arrive while invoke is still in flight. The error
+    // listener gates on `agentStatus === "running"`, so the status must
+    // already be "running" by the time invoke is awaited.
+    let statusDuringInvoke: string | undefined;
+    invokeMock.mockImplementationOnce(async () => {
+      statusDuringInvoke = useStore.getState().agentStatus;
+    });
+
+    await useStore.getState().startAgent("fresh goal");
+
+    expect(statusDuringInvoke).toBe("running");
+  });
+
+  it("surfaces non-AlreadyRunning rejections as agentStatus=error on a fresh start", async () => {
+    invokeMock.mockRejectedValueOnce({
+      kind: "Internal",
+      message: "MCP binary not found",
+    });
+
+    await useStore.getState().startAgent("fresh goal");
+
+    const state = useStore.getState();
+    expect(state.agentStatus).toBe("error");
+    expect(state.agentError).toBe("MCP binary not found");
+    const lastLog = useStore.getState().logs.at(-1);
+    expect(lastLog).toContain("Agent start rejected");
+  });
 });
 
 describe("agentSlice approval actions", () => {

--- a/ui/src/store/slices/agentSlice.test.ts
+++ b/ui/src/store/slices/agentSlice.test.ts
@@ -109,6 +109,24 @@ describe("agentSlice.startAgent", () => {
     expect(statusDuringInvoke).toBe("running");
   });
 
+  it("clears a leftover agentRunId on a fresh start so stale events from the prior run are dropped", async () => {
+    // After a run reaches a terminal state, `agentRunId` is not cleared
+    // automatically — terminal event handlers leave it in place. A fresh
+    // start from "complete"/"stopped"/"error" must null it out so any
+    // late in-flight event from the prior run fails `isStaleRunId`
+    // instead of being accepted into the new run's state.
+    useStore.getState().setAgentRunId("run-prior");
+    useStore.getState().setAgentStatus("complete");
+    let runIdDuringInvoke: string | null | undefined;
+    invokeMock.mockImplementationOnce(async () => {
+      runIdDuringInvoke = useStore.getState().agentRunId;
+    });
+
+    await useStore.getState().startAgent("fresh goal");
+
+    expect(runIdDuringInvoke).toBeNull();
+  });
+
   it("surfaces non-AlreadyRunning rejections as agentStatus=error on a fresh start", async () => {
     invokeMock.mockRejectedValueOnce({
       kind: "Internal",

--- a/ui/src/store/slices/agentSlice.test.ts
+++ b/ui/src/store/slices/agentSlice.test.ts
@@ -16,8 +16,6 @@ describe("agentSlice.startAgent", () => {
   });
 
   it("preserves the active run's state when invoke rejects with AlreadyRunning", async () => {
-    // Simulate an in-flight run: the original startAgent already installed
-    // a run ID and accumulated step/approval state.
     useStore.getState().setAgentRunId("run-prior");
     useStore.getState().setAgentStatus("running");
     useStore.getState().addAgentStep({

--- a/ui/src/store/slices/agentSlice.test.ts
+++ b/ui/src/store/slices/agentSlice.test.ts
@@ -15,30 +15,62 @@ describe("agentSlice.startAgent", () => {
     useStore.getState().resetAgent();
   });
 
-  it("surfaces AlreadyRunning rejections into agentStatus=error", async () => {
+  it("preserves the active run's state when invoke rejects with AlreadyRunning", async () => {
+    // Simulate an in-flight run: the original startAgent already installed
+    // a run ID and accumulated step/approval state.
+    useStore.getState().setAgentRunId("run-prior");
+    useStore.getState().setAgentStatus("running");
+    useStore.getState().addAgentStep({
+      summary: "prior step",
+      toolName: "click",
+      toolArgs: null,
+      toolResult: "ok",
+      pageTransitioned: false,
+    });
+    useStore.getState().setPendingApproval({
+      stepIndex: 0,
+      toolName: "click",
+      arguments: {},
+      description: "Click the button",
+    });
+
     invokeMock.mockRejectedValueOnce({
       kind: "AlreadyRunning",
       message: "Already running",
     });
 
-    await useStore.getState().startAgent("do something");
+    await useStore.getState().startAgent("duplicate goal");
 
     const state = useStore.getState();
-    expect(state.agentStatus).toBe("error");
-    expect(state.agentError).toBe("Already running");
+    // The rejection path must NOT wipe the live run — otherwise
+    // useAgentEvents drops every subsequent event as stale.
+    expect(state.agentRunId).toBe("run-prior");
+    expect(state.agentStatus).toBe("running");
+    expect(state.agentSteps).toHaveLength(1);
+    expect(state.pendingApproval).not.toBeNull();
+    expect(state.agentError).toBeNull();
+    const lastLog = useStore.getState().logs.at(-1);
+    expect(lastLog).toContain("Agent start rejected");
+    expect(lastLog).toContain("Already running");
   });
 
-  it("surfaces string-serialized AlreadyRunning rejections into agentStatus=error", async () => {
+  it("preserves the active run's state when invoke rejects with a string error", async () => {
+    useStore.getState().setAgentRunId("run-prior");
+    useStore.getState().setAgentStatus("running");
+
     invokeMock.mockRejectedValueOnce("AlreadyRunning: Already running");
 
-    await useStore.getState().startAgent("do something");
+    await useStore.getState().startAgent("duplicate goal");
 
     const state = useStore.getState();
-    expect(state.agentStatus).toBe("error");
-    expect(state.agentError).toMatch(/already running/i);
+    expect(state.agentRunId).toBe("run-prior");
+    expect(state.agentStatus).toBe("running");
+    const lastLog = useStore.getState().logs.at(-1);
+    expect(lastLog).toMatch(/agent start rejected/i);
+    expect(lastLog).toMatch(/already running/i);
   });
 
-  it("stays in running state when invoke succeeds", async () => {
+  it("resets run state and enters running state when invoke succeeds", async () => {
     invokeMock.mockResolvedValueOnce(undefined);
 
     await useStore.getState().startAgent("do something else");
@@ -46,9 +78,12 @@ describe("agentSlice.startAgent", () => {
     const state = useStore.getState();
     expect(state.agentStatus).toBe("running");
     expect(state.agentError).toBeNull();
+    expect(state.agentGoal).toBe("do something else");
+    expect(state.agentSteps).toEqual([]);
+    expect(state.pendingApproval).toBeNull();
   });
 
-  it("clears the previous agentRunId before invoke so stale events are treated as stale", async () => {
+  it("clears the previous agentRunId after a successful invoke so agent://started can install a fresh one", async () => {
     useStore.getState().setAgentRunId("run-prior");
     invokeMock.mockResolvedValueOnce(undefined);
 

--- a/ui/src/store/slices/agentSlice.ts
+++ b/ui/src/store/slices/agentSlice.ts
@@ -36,6 +36,21 @@ function formatAgentError(err: unknown): string {
   return String(err);
 }
 
+/**
+ * True when the rejection is the backend's `AlreadyRunning` refusal —
+ * either the structured `{ kind: "AlreadyRunning" }` or the string
+ * form `"AlreadyRunning: ..."` that `Display` produces.
+ */
+function isAlreadyRunningError(err: unknown): boolean {
+  if (err && typeof err === "object" && "kind" in err) {
+    return (err as { kind?: unknown }).kind === "AlreadyRunning";
+  }
+  if (typeof err === "string") {
+    return err.startsWith("AlreadyRunning");
+  }
+  return false;
+}
+
 export interface AgentSlice {
   agentStatus: AgentStatus;
   agentGoal: string;
@@ -72,7 +87,9 @@ export const createAgentSlice: StateCreator<StoreState, [], [], AgentSlice> = (
   agentRunId: null,
 
   startAgent: async (goal) => {
-    const { pushLog, agentConfig, projectPath, workflow, agentStatus } = get();
+    const priorState = get();
+    const { pushLog, agentConfig, projectPath, workflow, agentStatus } =
+      priorState;
     // If a run is already active, do not touch run-scoped state: the
     // backend will reject with AlreadyRunning and the live run's events
     // must keep routing through useAgentEvents. Otherwise optimistically
@@ -81,6 +98,20 @@ export const createAgentSlice: StateCreator<StoreState, [], [], AgentSlice> = (
     // failure) can flip status to "error" — their handler gates on
     // `agentStatus === "running"`.
     const wasActive = agentStatus === "running";
+    // Snapshot the prior run's visible state so we can restore it if
+    // the backend rejects with AlreadyRunning during its async cleanup
+    // window (handle still set but previous run has emitted its
+    // terminal event). Without this, a restart attempt in that window
+    // would wipe the terminal run's history and log it as "error".
+    const snapshot = {
+      agentStatus: priorState.agentStatus,
+      agentGoal: priorState.agentGoal,
+      agentSteps: priorState.agentSteps,
+      agentError: priorState.agentError,
+      currentAgentStep: priorState.currentAgentStep,
+      pendingApproval: priorState.pendingApproval,
+      agentRunId: priorState.agentRunId,
+    };
     if (!wasActive) {
       set({
         agentStatus: "running",
@@ -111,12 +142,18 @@ export const createAgentSlice: StateCreator<StoreState, [], [], AgentSlice> = (
     } catch (err) {
       const msg = formatAgentError(err);
       pushLog(`Agent start rejected: ${msg}`);
-      // Only surface the error into visible state if we optimistically
-      // flipped to "running". If a live run was already active, leave
-      // its state intact so its events continue to route.
-      if (!wasActive) {
-        set({ agentStatus: "error", agentError: msg });
+      if (wasActive) {
+        // A live run was already active — its state was never touched,
+        // and its events must keep routing.
+        return;
       }
+      if (isAlreadyRunningError(err)) {
+        // Backend is still tearing down the previous run. Restore its
+        // visible state so its terminal history is not lost.
+        set(snapshot);
+        return;
+      }
+      set({ agentStatus: "error", agentError: msg });
     }
   },
 

--- a/ui/src/store/slices/agentSlice.ts
+++ b/ui/src/store/slices/agentSlice.ts
@@ -88,6 +88,13 @@ export const createAgentSlice: StateCreator<StoreState, [], [], AgentSlice> = (
       // run-scoped state untouched keeps the still-live original run's
       // events routing through useAgentEvents instead of being dropped
       // as stale.
+      //
+      // Do NOT clobber `agentRunId` here. The backend emits
+      // `agent://started` synchronously *before* `run_agent` returns, so
+      // the listener may have already installed the new run's ID by the
+      // time this continuation runs. Overwriting it with null would race
+      // with that listener and leave every subsequent event looking
+      // stale under `isStaleRunId`.
       set({
         agentStatus: "running",
         agentGoal: goal,
@@ -95,7 +102,6 @@ export const createAgentSlice: StateCreator<StoreState, [], [], AgentSlice> = (
         agentError: null,
         currentAgentStep: 0,
         pendingApproval: null,
-        agentRunId: null,
       });
       pushLog(`Agent started with goal: ${goal}`);
     } catch (err) {

--- a/ui/src/store/slices/agentSlice.ts
+++ b/ui/src/store/slices/agentSlice.ts
@@ -80,11 +80,6 @@ export const createAgentSlice: StateCreator<StoreState, [], [], AgentSlice> = (
     // terminal events (e.g. `agent://error` from a fast MCP-spawn
     // failure) can flip status to "error" — their handler gates on
     // `agentStatus === "running"`.
-    //
-    // `agentRunId` is intentionally left to `agent://started`: the
-    // backend emits that event before `run_agent` returns, and
-    // clobbering it here would race with the listener and leave every
-    // subsequent event looking stale under `isStaleRunId`.
     const wasActive = agentStatus === "running";
     if (!wasActive) {
       set({
@@ -94,6 +89,12 @@ export const createAgentSlice: StateCreator<StoreState, [], [], AgentSlice> = (
         agentError: null,
         currentAgentStep: 0,
         pendingApproval: null,
+        // Clear the prior run's ID so any late in-flight events from it
+        // fail `isStaleRunId` (which drops events when active is null).
+        // `agent://started` from the new run will install the fresh ID;
+        // setting null here — not after invoke — avoids racing with that
+        // listener.
+        agentRunId: null,
       });
       pushLog(`Agent started with goal: ${goal}`);
     }

--- a/ui/src/store/slices/agentSlice.ts
+++ b/ui/src/store/slices/agentSlice.ts
@@ -73,16 +73,6 @@ export const createAgentSlice: StateCreator<StoreState, [], [], AgentSlice> = (
 
   startAgent: async (goal) => {
     const { pushLog, agentConfig, projectPath, workflow } = get();
-    set({
-      agentStatus: "running",
-      agentGoal: goal,
-      agentSteps: [],
-      agentError: null,
-      currentAgentStep: 0,
-      pendingApproval: null,
-      agentRunId: null,
-    });
-    pushLog(`Agent started with goal: ${goal}`);
     try {
       await invoke("run_agent", {
         request: {
@@ -93,10 +83,22 @@ export const createAgentSlice: StateCreator<StoreState, [], [], AgentSlice> = (
           workflow_id: workflow.id,
         },
       });
+      // Only reset visible run state once the backend has accepted the
+      // request. If invoke rejects (e.g. AlreadyRunning) we must leave
+      // agentRunId, agentSteps, pendingApproval, and agentStatus alone
+      // so the original run's events continue to route to the UI.
+      set({
+        agentStatus: "running",
+        agentGoal: goal,
+        agentSteps: [],
+        agentError: null,
+        currentAgentStep: 0,
+        pendingApproval: null,
+        agentRunId: null,
+      });
+      pushLog(`Agent started with goal: ${goal}`);
     } catch (err) {
-      const msg = formatAgentError(err);
-      set({ agentStatus: "error", agentError: msg });
-      pushLog(`Agent failed: ${msg}`);
+      pushLog(`Agent start rejected: ${formatAgentError(err)}`);
     }
   },
 

--- a/ui/src/store/slices/agentSlice.ts
+++ b/ui/src/store/slices/agentSlice.ts
@@ -72,7 +72,31 @@ export const createAgentSlice: StateCreator<StoreState, [], [], AgentSlice> = (
   agentRunId: null,
 
   startAgent: async (goal) => {
-    const { pushLog, agentConfig, projectPath, workflow } = get();
+    const { pushLog, agentConfig, projectPath, workflow, agentStatus } = get();
+    // If a run is already active, do not touch run-scoped state: the
+    // backend will reject with AlreadyRunning and the live run's events
+    // must keep routing through useAgentEvents. Otherwise optimistically
+    // reset into the "running" shape before awaiting invoke, so early
+    // terminal events (e.g. `agent://error` from a fast MCP-spawn
+    // failure) can flip status to "error" — their handler gates on
+    // `agentStatus === "running"`.
+    //
+    // `agentRunId` is intentionally left to `agent://started`: the
+    // backend emits that event before `run_agent` returns, and
+    // clobbering it here would race with the listener and leave every
+    // subsequent event looking stale under `isStaleRunId`.
+    const wasActive = agentStatus === "running";
+    if (!wasActive) {
+      set({
+        agentStatus: "running",
+        agentGoal: goal,
+        agentSteps: [],
+        agentError: null,
+        currentAgentStep: 0,
+        pendingApproval: null,
+      });
+      pushLog(`Agent started with goal: ${goal}`);
+    }
     try {
       await invoke("run_agent", {
         request: {
@@ -83,29 +107,15 @@ export const createAgentSlice: StateCreator<StoreState, [], [], AgentSlice> = (
           workflow_id: workflow.id,
         },
       });
-      // Reset visible run state only after the backend accepts. On
-      // rejection (e.g. AlreadyRunning from a duplicate click), leaving
-      // run-scoped state untouched keeps the still-live original run's
-      // events routing through useAgentEvents instead of being dropped
-      // as stale.
-      //
-      // Do NOT clobber `agentRunId` here. The backend emits
-      // `agent://started` synchronously *before* `run_agent` returns, so
-      // the listener may have already installed the new run's ID by the
-      // time this continuation runs. Overwriting it with null would race
-      // with that listener and leave every subsequent event looking
-      // stale under `isStaleRunId`.
-      set({
-        agentStatus: "running",
-        agentGoal: goal,
-        agentSteps: [],
-        agentError: null,
-        currentAgentStep: 0,
-        pendingApproval: null,
-      });
-      pushLog(`Agent started with goal: ${goal}`);
     } catch (err) {
-      pushLog(`Agent start rejected: ${formatAgentError(err)}`);
+      const msg = formatAgentError(err);
+      pushLog(`Agent start rejected: ${msg}`);
+      // Only surface the error into visible state if we optimistically
+      // flipped to "running". If a live run was already active, leave
+      // its state intact so its events continue to route.
+      if (!wasActive) {
+        set({ agentStatus: "error", agentError: msg });
+      }
     }
   },
 

--- a/ui/src/store/slices/agentSlice.ts
+++ b/ui/src/store/slices/agentSlice.ts
@@ -83,10 +83,11 @@ export const createAgentSlice: StateCreator<StoreState, [], [], AgentSlice> = (
           workflow_id: workflow.id,
         },
       });
-      // Only reset visible run state once the backend has accepted the
-      // request. If invoke rejects (e.g. AlreadyRunning) we must leave
-      // agentRunId, agentSteps, pendingApproval, and agentStatus alone
-      // so the original run's events continue to route to the UI.
+      // Reset visible run state only after the backend accepts. On
+      // rejection (e.g. AlreadyRunning from a duplicate click), leaving
+      // run-scoped state untouched keeps the still-live original run's
+      // events routing through useAgentEvents instead of being dropped
+      // as stale.
       set({
         agentStatus: "running",
         agentGoal: goal,


### PR DESCRIPTION
## Summary

- Fix a duplicate-start desync in `agentSlice.startAgent`: the state reset (including wiping `agentRunId`, `agentSteps`, `pendingApproval`, and flipping `agentStatus` to `"error"` on failure) now runs pre-invoke only for fresh starts, so an `AlreadyRunning` rejection no longer wipes a live run's UI state.
- Preserve `agentRunId` ownership with `agent://started`: the listener can install the new run's ID before `invoke` resolves, so the success path no longer clobbers it back to `null`.
- Status flips to `"running"` before `await invoke`, so early terminal events (e.g. `agent://error` from a fast MCP-spawn failure) are recorded through the `current === "running"` gate instead of being silently logged.
- Null the prior `agentRunId` on fresh restart from a terminal state so the null-gap fence drops late in-flight events from the old run under `isStaleRunId`.
- Snapshot and restore visible run state when `AlreadyRunning` fires during the backend's async cleanup window after a terminal event — a transient rejection no longer converts to an `"error"` state or loses the prior run's history.

## Test plan

- [x] `cd ui && npx tsc -b` (typecheck)
- [x] `cd ui && npx vitest run src/store/slices/agentSlice.test.ts src/hooks/events/useAgentEvents.test.ts` — 14/14 pass
- [x] `cd ui && npx vitest run` — 166/166 tests pass (the 6 file-level vitest failures under `src/cdp-scripts/` are a pre-existing vite `fs.allow` issue in worktrees, unrelated)
- [x] Each new test fails on the prior buggy slice and passes on the fix (verified by stashing `agentSlice.ts` during review)